### PR TITLE
Player controls additions

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -161,7 +161,7 @@ static void gameProc(void* arg) {
     contactSolverInit(&gContactSolver);
     portalSurfaceCleanupQueueInit();
     savefileNew();
-    levelLoad(6);
+    levelLoad(0);
     cutsceneRunnerReset();
     controllersInit();
     initAudio(fps);

--- a/src/math/mathf.h
+++ b/src/math/mathf.h
@@ -23,6 +23,8 @@ float powf(float base, float exp);
 
 float cosf(float in);
 float sinf(float in);
+double atan2(double x, double y);
+double asin(double in);
 float fabsf(float in);
 float floorf(float in);
 float ceilf(float in);

--- a/src/math/quaternion.c
+++ b/src/math/quaternion.c
@@ -291,3 +291,37 @@ void quatDecompose(struct Quaternion* input, struct Vector3* axis, float* angle)
 float quatDot(struct Quaternion* a, struct Quaternion* b) {
     return a->x * b->x + a->y * b->y + a->z * b->z + a->w * b->w;
 }
+
+void quat_fromEulerZYX(struct Vector3 eulerZYX, struct Quaternion* out){
+    double cy = cos(eulerZYX.x * 0.5);
+    double sy = sin(eulerZYX.x * 0.5);
+    double cr = cos(eulerZYX.z * 0.5);
+    double sr = sin(eulerZYX.z * 0.5);
+    double cp = cos(eulerZYX.y * 0.5);
+    double sp = sin(eulerZYX.y * 0.5);
+
+    out->w = cy * cr * cp + sy * sr * sp;
+    out->x = cy * sr * cp - sy * cr * sp;
+    out->y = cy * cr * sp + sy * sr * cp;
+    out->z = sy * cr * cp - cy * sr * sp;
+}
+
+void quat_toEulerZYX(struct Quaternion q, struct Vector3* out){
+    double pi = 3.14159265358979323846264338327950288419716939937510582097494459230781640628620899862803482534211706798214808651328230664709384460955058223172535940812848111745028410270193852110555964462294895493038196442881097566593344612847564823378678316527120190914564856692346034861045432664821339360726024914127372458700660631558817488152092096282925409171536436789259036001133053054882046652138414695194151160943305727036575959195309218611738193261179310511854807446237996274956735188575272489122793818301194912983367336244065664308602139494639522473;
+    // Roll (x-axis rotation)
+    double sinr_cosp = +2.0 * (q.w * q.x + q.y * q.z);
+    double cosr_cosp = +1.0 - 2.0 * (q.x * q.x + q.y * q.y);
+    out->z = atan2(sinr_cosp, cosr_cosp);// could be wrong??
+
+    // Pitch (y-axis rotation)
+    double sinp = +2.0 * (q.w * q.y - q.z * q.x);
+    if (fabsf(sinp) >= 1)
+        out->y = (pi / 2) *signf(sinp); // use 90 degrees if out of range
+    else
+        out->y = asin(sinp);
+
+    // Yaw (z-axis rotation)
+    double siny_cosp = +2.0 * (q.w * q.z + q.x * q.y);
+    double cosy_cosp = +1.0 - 2.0 * (q.y * q.y + q.z * q.z);
+    out->x = atan2(siny_cosp, cosy_cosp);
+}

--- a/src/math/quaternion.c
+++ b/src/math/quaternion.c
@@ -293,6 +293,15 @@ float quatDot(struct Quaternion* a, struct Quaternion* b) {
 }
 
 void quat_fromEulerZYX(struct Vector3 eulerZYX, struct Quaternion* out){
+    /*
+    Convert Euler to Quaterion.
+
+    Args:
+        eulerZYX: Euler to convert
+        out: Output quaternion
+    Returns:
+        None
+    */
     double cy = cos(eulerZYX.x * 0.5);
     double sy = sin(eulerZYX.x * 0.5);
     double cr = cos(eulerZYX.z * 0.5);
@@ -307,20 +316,27 @@ void quat_fromEulerZYX(struct Vector3 eulerZYX, struct Quaternion* out){
 }
 
 void quat_toEulerZYX(struct Quaternion q, struct Vector3* out){
-    double pi = 3.14159265358979323846264338327950288419716939937510582097494459230781640628620899862803482534211706798214808651328230664709384460955058223172535940812848111745028410270193852110555964462294895493038196442881097566593344612847564823378678316527120190914564856692346034861045432664821339360726024914127372458700660631558817488152092096282925409171536436789259036001133053054882046652138414695194151160943305727036575959195309218611738193261179310511854807446237996274956735188575272489122793818301194912983367336244065664308602139494639522473;
-    // Roll (x-axis rotation)
+    /*
+    Convert Quaterion to Euler.
+
+    Args:
+        q: Quaterion to convert
+        out: Output Euler
+    Returns:
+        None
+    */
+    double pi = 3.1415926535897932384626433832795028841;
+
     double sinr_cosp = +2.0 * (q.w * q.x + q.y * q.z);
     double cosr_cosp = +1.0 - 2.0 * (q.x * q.x + q.y * q.y);
     out->z = atan2(sinr_cosp, cosr_cosp);// could be wrong??
 
-    // Pitch (y-axis rotation)
     double sinp = +2.0 * (q.w * q.y - q.z * q.x);
     if (fabsf(sinp) >= 1)
         out->y = (pi / 2) *signf(sinp); // use 90 degrees if out of range
     else
         out->y = asin(sinp);
 
-    // Yaw (z-axis rotation)
     double siny_cosp = +2.0 * (q.w * q.z + q.x * q.y);
     double cosy_cosp = +1.0 - 2.0 * (q.y * q.y + q.z * q.z);
     out->x = atan2(siny_cosp, cosy_cosp);

--- a/src/math/quaternion.h
+++ b/src/math/quaternion.h
@@ -31,5 +31,7 @@ void quatApplyAngularVelocity(struct Quaternion* input, struct Vector3* w, float
 void quatDecompose(struct Quaternion* input, struct Vector3* axis, float* angle);
 
 float quatDot(struct Quaternion* a, struct Quaternion* b);
+void quat_fromEulerZYX(struct Vector3 eulerZYX, struct Quaternion* out);
+void quat_toEulerZYX(struct Quaternion q, struct Vector3* out);
 
 #endif

--- a/src/physics/collision_object.c
+++ b/src/physics/collision_object.c
@@ -17,6 +17,12 @@ void collisionObjectInit(struct CollisionObject* object, struct ColliderTypeData
     object->manifoldIds = 0;
 }
 
+void collisionObjectReInit(struct CollisionObject* object, struct ColliderTypeData *collider, struct RigidBody* body, float mass, int collisionLayers) {
+    object->collider = collider;
+    object->body = body;
+    collisionObjectUpdateBB(object);
+}
+
 int collisionObjectIsActive(struct CollisionObject* object) {
     return object->body && ((object->body->flags & (RigidBodyIsKinematic | RigidBodyIsSleeping)) == 0);
 }

--- a/src/physics/collision_object.h
+++ b/src/physics/collision_object.h
@@ -39,6 +39,7 @@ int collisionObjectIsActive(struct CollisionObject* object);
 int collisionObjectShouldGenerateConctacts(struct CollisionObject* object);
 
 void collisionObjectInit(struct CollisionObject* object, struct ColliderTypeData *collider, struct RigidBody* body, float mass, int collisionLayers);
+void collisionObjectReInit(struct CollisionObject* object, struct ColliderTypeData *collider, struct RigidBody* body, float mass, int collisionLayers);
 
 void collisionObjectCollideWithQuad(struct CollisionObject* object, struct CollisionObject* quad, struct ContactSolver* contactSolver);
 void collisionObjectCollideWithQuadSwept(struct CollisionObject* object, struct Vector3* objectPrevPos, struct Box3D* sweptBB, struct CollisionObject* quadObject, struct ContactSolver* contactSolver);

--- a/src/player/player.h
+++ b/src/player/player.h
@@ -21,6 +21,7 @@ enum PlayerFlags {
     PlayerHasSecondPortalGun = (1 << 2),
     PlayerIsDead = (1 << 3),
     PlayerIsUnderwater = (1 << 4),
+    PlayerCrouched = (1 << 5),
 };
 
 struct Player {
@@ -42,6 +43,8 @@ struct Player {
 };
 
 void playerInit(struct Player* player, struct Location* startLocation, struct Vector3* velocity);
+void playerLookStraight(struct Player* player);
+int playerLookingTooFarUpDown(struct Player* player, float threshold);
 void playerUpdate(struct Player* player, struct Transform* cameraTransform);
 
 void playerGetMoveBasis(struct Transform* transform, struct Vector3* forward, struct Vector3* right);


### PR DESCRIPTION
feature additions:
- c up is now "look directly forward" control
- c down is now "look directly backward" control
- c right is now crouch control
- c left no longer has a function
- added euler to quaterion conversion function
- added quaternion to euler conversion function
- the player cant look straight or backward if looking directly up or down
- tested in all chambers, no bugs found

Only thing not implemented with these features is Chell actually doing a crouching animation while crouching. I believe this could be accomplished in a future pull request.