### PR TITLE
True HUD Implementation

### DIFF
--- a/src/levels/cutscene_runner.c
+++ b/src/levels/cutscene_runner.c
@@ -149,7 +149,7 @@ void cutsceneRunnerStartStep(struct CutsceneRunner* runner) {
             quatMultVector(&location->transform.rotation, &gRight, &transformUp);
             vector3Negate(&transformUp, &transformUp);
             vector3AddScaled(&location->transform.position, &firingRay.dir, -0.1f, &firingRay.origin);
-            sceneFirePortal(&gScene, &firingRay, &transformUp, step->openPortal.portalIndex, location->roomIndex, 0);
+            sceneFirePortal(&gScene, &firingRay, &transformUp, step->openPortal.portalIndex, location->roomIndex, 0, 0);
             break;
         }
         case CutsceneStepTypeClosePortal:

--- a/src/scene/hud.c
+++ b/src/scene/hud.c
@@ -23,7 +23,7 @@
 #define HUD_LOWER_X ((SCREEN_WD - HUD_OUTER_WIDTH + (HUD_OUTER_OFFSET_X << 1)) << 1)
 #define HUD_LOWER_Y ((SCREEN_HT - HUD_OUTER_HEIGHT + (HUD_OUTER_OFFSET_Y << 1)) << 1)
 
-void hudRender(struct RenderState* renderState, int playerFlags, int portal_0_present, int portal_1_present) {
+void hudRender(struct RenderState* renderState, int playerFlags, int last_portal_idx_shot, int looked_wall_portalable) {
     if (playerFlags & PlayerIsDead) {
         gSPDisplayList(renderState->dl++, hud_death_overlay);
         gDPFillRectangle(renderState->dl++, 0, 0, SCREEN_WD, SCREEN_HT);
@@ -32,41 +32,61 @@ void hudRender(struct RenderState* renderState, int playerFlags, int portal_0_pr
 
     gSPDisplayList(renderState->dl++, hud_material_list[PORTAL_CROSSHAIRS_INDEX]);
 
-    // gSPTextureRectangle(renderState->dl++, 
-    //     (SCREEN_WD - HUD_CENTER_WIDTH) << 1, (SCREEN_HT - HUD_CENTER_HEIGHT) << 1, 
-    //     (SCREEN_WD + HUD_CENTER_WIDTH) << 1, (SCREEN_HT + HUD_CENTER_HEIGHT) << 1, 
-    //     G_TX_RENDERTILE, HUD_CENTER_S << 5, HUD_CENTER_T << 5, 1 << 10, 1 << 10);
+    int position_of_left_asset = 0; // position from original image to clip out left hud asset
+    int position_of_right_asset = HUD_OUTER_WIDTH; // position from original image to clip out right hud asset
+    int position_of_portal_indicator = HUD_OUTER_WIDTH*4;
 
-    if (playerFlags & PlayerHasFirstPortalGun) {
+    //blue drawing
+    if (playerFlags & PlayerHasFirstPortalGun){
         gDPSetPrimColor(renderState->dl++, 255, 255, 0, 128, 255, 255);
-        if (portal_1_present){
-            gSPTextureRectangle(renderState->dl++, 
-                HUD_UPPER_X, HUD_UPPER_Y,
-                HUD_UPPER_X + (HUD_OUTER_WIDTH << 2), HUD_UPPER_Y + (HUD_OUTER_HEIGHT << 2), 
-                G_TX_RENDERTILE, (HUD_OUTER_WIDTH*2) << 5, 0 << 5, 1 << 10, 1 << 10);
+        if (looked_wall_portalable){
+            position_of_left_asset = (HUD_OUTER_WIDTH*2);
         }
-        else{
+        gSPTextureRectangle(renderState->dl++, 
+            HUD_UPPER_X, HUD_UPPER_Y,
+            HUD_UPPER_X + (HUD_OUTER_WIDTH << 2), HUD_UPPER_Y + (HUD_OUTER_HEIGHT << 2), 
+            G_TX_RENDERTILE, position_of_left_asset << 5, 0 << 5, 1 << 10, 1 << 10);
+        
+        // if the player has the first gun but not second both left and right are blue
+        if (!(playerFlags & PlayerHasSecondPortalGun)){
+            if (looked_wall_portalable){
+                position_of_right_asset = (HUD_OUTER_WIDTH*3);
+            }   
             gSPTextureRectangle(renderState->dl++, 
-                HUD_UPPER_X, HUD_UPPER_Y,
-                HUD_UPPER_X + (HUD_OUTER_WIDTH << 2), HUD_UPPER_Y + (HUD_OUTER_HEIGHT << 2), 
-                G_TX_RENDERTILE, 0 << 5, 0 << 5, 1 << 10, 1 << 10);
+                HUD_LOWER_X, HUD_LOWER_Y,
+                HUD_LOWER_X + (HUD_OUTER_WIDTH << 2), HUD_LOWER_Y + (HUD_OUTER_HEIGHT << 2), 
+                G_TX_RENDERTILE, position_of_right_asset << 5, 0 << 5, 1 << 10, 1 << 10);
         }
+        
     }
 
-    if (playerFlags & PlayerHasSecondPortalGun) {
+    //orange drawing
+    if (playerFlags & PlayerHasSecondPortalGun){
         gDPSetPrimColor(renderState->dl++, 255, 255, 255, 128, 0, 255);
-
-        if (portal_0_present){
-            gSPTextureRectangle(renderState->dl++, 
-                HUD_LOWER_X, HUD_LOWER_Y,
-                HUD_LOWER_X + (HUD_OUTER_WIDTH << 2), HUD_LOWER_Y + (HUD_OUTER_HEIGHT << 2), 
-                G_TX_RENDERTILE, (HUD_OUTER_WIDTH*3) << 5, 0 << 5, 1 << 10, 1 << 10);
+        if (looked_wall_portalable){
+            position_of_right_asset = (HUD_OUTER_WIDTH*3);
         }
-        else{
+        gSPTextureRectangle(renderState->dl++, 
+            HUD_LOWER_X, HUD_LOWER_Y,
+            HUD_LOWER_X + (HUD_OUTER_WIDTH << 2), HUD_LOWER_Y + (HUD_OUTER_HEIGHT << 2), 
+            G_TX_RENDERTILE, position_of_right_asset << 5, 0 << 5, 1 << 10, 1 << 10);
+    }
+
+    // both portal guns owned is only time when the last shot portal indicator appears
+    if ((playerFlags & PlayerHasSecondPortalGun) && (playerFlags & PlayerHasFirstPortalGun) && last_portal_idx_shot != -1){
+        if (last_portal_idx_shot == 0){
+            gDPSetPrimColor(renderState->dl++, 255, 255, 255, 128, 0, 255);
             gSPTextureRectangle(renderState->dl++, 
-                HUD_LOWER_X, HUD_LOWER_Y,
-                HUD_LOWER_X + (HUD_OUTER_WIDTH << 2), HUD_LOWER_Y + (HUD_OUTER_HEIGHT << 2), 
-                G_TX_RENDERTILE, HUD_OUTER_WIDTH << 5, 0 << 5, 1 << 10, 1 << 10);
+                HUD_UPPER_X + 100, HUD_LOWER_Y,
+                HUD_UPPER_X + 100 + (HUD_OUTER_WIDTH << 2), HUD_LOWER_Y + (HUD_OUTER_HEIGHT << 2) , 
+                G_TX_RENDERTILE, position_of_portal_indicator << 5, 0 << 5, 1 << 10, 1 << 10);
+        }
+        else if (last_portal_idx_shot == 1){
+            gDPSetPrimColor(renderState->dl++, 255, 255, 0, 128, 255, 255);
+            gSPTextureRectangle(renderState->dl++, 
+                HUD_LOWER_X - 68, HUD_LOWER_Y,
+                HUD_LOWER_X - 68 + (HUD_OUTER_WIDTH << 2), HUD_LOWER_Y + (HUD_OUTER_HEIGHT << 2) , 
+                G_TX_RENDERTILE, position_of_portal_indicator << 5, 0 << 5, 1 << 10, 1 << 10);
         }
     }
 }

--- a/src/scene/hud.h
+++ b/src/scene/hud.h
@@ -3,6 +3,6 @@
 
 #include "../graphics/renderstate.h"
 
-void hudRender(struct RenderState* renderState, int playerFlags, int portal_0_present, int portal_1_present);
+void hudRender(struct RenderState* renderState, int playerFlags, int last_portal_idx_shot, int looked_wall_portalable);
 
 #endif

--- a/src/scene/portal.c
+++ b/src/scene/portal.c
@@ -77,10 +77,13 @@ void portalUpdate(struct Portal* portal, int isOpen) {
     }
 }
 
-int portalAttachToSurface(struct Portal* portal, struct PortalSurface* surface, int surfaceIndex, struct Transform* portalAt) {
+int portalAttachToSurface(struct Portal* portal, struct PortalSurface* surface, int surfaceIndex, struct Transform* portalAt, int just_checking) {
     // determine if portal is on surface
     if (!portalSurfaceIsInside(surface, portalAt)) {
         return 0;
+    }
+    if (just_checking){
+        return 1;
     }
     // find all portal edge intersections
     struct Vector2s16 correctPosition;
@@ -88,6 +91,7 @@ int portalAttachToSurface(struct Portal* portal, struct PortalSurface* surface, 
     if (!portalSurfaceAdjustPosition(surface, portalAt, &correctPosition, portalOutline)) {
         return 0;
     }
+    
 
     for (int i = 0; i < PORTAL_LOOP_SIZE; ++i) {
         vector2s16Sub(&portalOutline[i], &correctPosition, &portal->originCentertedLoop[i]);

--- a/src/scene/portal.h
+++ b/src/scene/portal.h
@@ -48,7 +48,7 @@ extern struct Vector3 gPortalOutline[PORTAL_LOOP_SIZE];
 void portalInit(struct Portal* portal, enum PortalFlags flags);
 void portalUpdate(struct Portal* portal, int isOpen);
 
-int portalAttachToSurface(struct Portal* portal, struct PortalSurface* surface, int surfaceIndex, struct Transform* portalAt);
+int portalAttachToSurface(struct Portal* portal, struct PortalSurface* surface, int surfaceIndex, struct Transform* portalAt, int just_checking);
 void portalCheckForHoles(struct Portal* portals);
 
 // data should be of type struct Transform

--- a/src/scene/scene.h
+++ b/src/scene/scene.h
@@ -53,8 +53,8 @@ struct Scene {
     u8 switchCount;
     u8 ballLancherCount;
     u8 ballCatcherCount;
-    int portal_0_present;
-    int portal_1_present;
+    int last_portal_indx_shot;
+    int looked_wall_portalable;
 };
 
 extern struct Scene gScene;
@@ -65,7 +65,7 @@ void sceneInit(struct Scene* scene);
 void sceneRender(struct Scene* scene, struct RenderState* renderState, struct GraphicsTask* task);
 void sceneUpdate(struct Scene* scene);
 
-int sceneFirePortal(struct Scene* scene, struct Ray* ray, struct Vector3* playerUp, int portalIndex, int roomIndex, int fromPlayer);
+int sceneFirePortal(struct Scene* scene, struct Ray* ray, struct Vector3* playerUp, int portalIndex, int roomIndex, int fromPlayer, int just_checking);
 void sceneClosePortal(struct Scene* scene, int portalIndex);
 
 #endif


### PR DESCRIPTION
In the real game the HUD is constantly checking if you are looking at a valid wall to shoot a portal at. If you are, it displays both parts of the HUD as filled in. if you aren't they are both unfilled.

the HUD in the game also has a portal indicator on the side of the HUD corresponding to the portal you last shot (also in the corresponding color)

both of the above things have been implemented in this PR. also attached are images of it working.

![Screenshot 2023-03-04 21:43:35](https://user-images.githubusercontent.com/71656782/222940598-878c023e-9dee-4aab-9a59-ea15abb2d3bc.png)
![Screenshot 2023-03-04 21:44:23](https://user-images.githubusercontent.com/71656782/222940599-8b8085b9-678a-4b65-8b6b-62bf20754061.png)
![Screenshot 2023-03-04 21:46:16](https://user-images.githubusercontent.com/71656782/222940601-33760a5e-335a-4f84-a8a6-01ae25bfc6e3.png)
![Screenshot 2023-03-04 21:46:33](https://user-images.githubusercontent.com/71656782/222940603-829bcfd9-f625-4f2f-bc39-65aed00592f9.png)
![Screenshot 2023-03-04 21:47:02](https://user-images.githubusercontent.com/71656782/222940604-f16fbc66-a3c2-42e7-8634-5a016af1c8ac.png)
![Screenshot 2023-03-04 21:47:26](https://user-images.githubusercontent.com/71656782/222940605-1a99c775-9c47-4424-9be5-a999deb21f9c.png)

I had to add a flag "just_checking" to a few functions involved when the player normally shoots a portal and the validity checks are run. This flag tells the functions to not actually shoot a new portal but just check if shooting a portal would be valid.