### PR TITLE
HUD Finishing Touches

### DIFF
--- a/src/player/player.c
+++ b/src/player/player.c
@@ -227,12 +227,15 @@ void playerApplyPortalGrab(struct Player* player, int portalIndex) {
 
 void playerSetGrabbing(struct Player* player, struct CollisionObject* grabbing) {
     if (grabbing && !player->grabConstraint.object) {
+        player->flags |= PlayerIsGrabbing;
         pointConstraintInit(&player->grabConstraint, grabbing, 8.0f, 5.0f);
         contactSolverAddPointConstraint(&gContactSolver, &player->grabConstraint);
     } else if (!grabbing && player->grabConstraint.object) {
+        player->flags &= ~PlayerIsGrabbing;
         player->grabConstraint.object = NULL;
         contactSolverRemovePointConstraint(&gContactSolver, &player->grabConstraint);
     } else if (grabbing != player->grabConstraint.object) {
+        player->flags |= PlayerIsGrabbing;
         pointConstraintInit(&player->grabConstraint, grabbing, 8.0f, 5.0f);
     }
 }

--- a/src/player/player.h
+++ b/src/player/player.h
@@ -22,6 +22,7 @@ enum PlayerFlags {
     PlayerIsDead = (1 << 3),
     PlayerIsUnderwater = (1 << 4),
     PlayerCrouched = (1 << 5),
+    PlayerIsGrabbing = (1 << 6),
 };
 
 struct Player {

--- a/src/scene/hud.c
+++ b/src/scene/hud.c
@@ -23,7 +23,7 @@
 #define HUD_LOWER_X ((SCREEN_WD - HUD_OUTER_WIDTH + (HUD_OUTER_OFFSET_X << 1)) << 1)
 #define HUD_LOWER_Y ((SCREEN_HT - HUD_OUTER_HEIGHT + (HUD_OUTER_OFFSET_Y << 1)) << 1)
 
-void hudRender(struct RenderState* renderState, int playerFlags, int last_portal_idx_shot, int looked_wall_portalable) {
+void hudRender(struct RenderState* renderState, int playerFlags, int last_portal_idx_shot, int looked_wall_portalable_0, int looked_wall_portalable_1) {
     if (playerFlags & PlayerIsDead) {
         gSPDisplayList(renderState->dl++, hud_death_overlay);
         gDPFillRectangle(renderState->dl++, 0, 0, SCREEN_WD, SCREEN_HT);
@@ -36,41 +36,56 @@ void hudRender(struct RenderState* renderState, int playerFlags, int last_portal
     int position_of_right_asset = HUD_OUTER_WIDTH; // position from original image to clip out right hud asset
     int position_of_portal_indicator = HUD_OUTER_WIDTH*4;
 
-    //blue drawing
-    if (playerFlags & PlayerHasFirstPortalGun){
-        gDPSetPrimColor(renderState->dl++, 255, 255, 0, 128, 255, 255);
-        if (looked_wall_portalable){
-            position_of_left_asset = (HUD_OUTER_WIDTH*2);
-        }
+    // white hud because player is grabbing
+    if ((playerFlags & PlayerIsGrabbing) && (playerFlags & PlayerHasFirstPortalGun) ){
+        gDPSetPrimColor(renderState->dl++, 255, 255, 255, 255, 255, 255);
         gSPTextureRectangle(renderState->dl++, 
             HUD_UPPER_X, HUD_UPPER_Y,
             HUD_UPPER_X + (HUD_OUTER_WIDTH << 2), HUD_UPPER_Y + (HUD_OUTER_HEIGHT << 2), 
             G_TX_RENDERTILE, position_of_left_asset << 5, 0 << 5, 1 << 10, 1 << 10);
-        
-        // if the player has the first gun but not second both left and right are blue
-        if (!(playerFlags & PlayerHasSecondPortalGun)){
-            if (looked_wall_portalable){
+        gSPTextureRectangle(renderState->dl++, 
+                HUD_LOWER_X, HUD_LOWER_Y,
+                HUD_LOWER_X + (HUD_OUTER_WIDTH << 2), HUD_LOWER_Y + (HUD_OUTER_HEIGHT << 2), 
+                G_TX_RENDERTILE, position_of_right_asset << 5, 0 << 5, 1 << 10, 1 << 10);
+    }
+    // else blue and orange logic
+    else{
+        //blue drawing
+        if (playerFlags & PlayerHasFirstPortalGun){
+            gDPSetPrimColor(renderState->dl++, 255, 255, 0, 128, 255, 255);
+            if (looked_wall_portalable_1){
+                position_of_left_asset = (HUD_OUTER_WIDTH*2);
+            }
+            gSPTextureRectangle(renderState->dl++, 
+                HUD_UPPER_X, HUD_UPPER_Y,
+                HUD_UPPER_X + (HUD_OUTER_WIDTH << 2), HUD_UPPER_Y + (HUD_OUTER_HEIGHT << 2), 
+                G_TX_RENDERTILE, position_of_left_asset << 5, 0 << 5, 1 << 10, 1 << 10);
+            
+            // if the player has the first gun but not second both left and right are blue
+            if (!(playerFlags & PlayerHasSecondPortalGun)){
+                if (looked_wall_portalable_1){
+                    position_of_right_asset = (HUD_OUTER_WIDTH*3);
+                }   
+                gSPTextureRectangle(renderState->dl++, 
+                    HUD_LOWER_X, HUD_LOWER_Y,
+                    HUD_LOWER_X + (HUD_OUTER_WIDTH << 2), HUD_LOWER_Y + (HUD_OUTER_HEIGHT << 2), 
+                    G_TX_RENDERTILE, position_of_right_asset << 5, 0 << 5, 1 << 10, 1 << 10);
+            }
+            
+        }
+        //orange drawing
+        if (playerFlags & PlayerHasSecondPortalGun){
+            gDPSetPrimColor(renderState->dl++, 255, 255, 255, 128, 0, 255);
+            if (looked_wall_portalable_0){
                 position_of_right_asset = (HUD_OUTER_WIDTH*3);
-            }   
+            }
             gSPTextureRectangle(renderState->dl++, 
                 HUD_LOWER_X, HUD_LOWER_Y,
                 HUD_LOWER_X + (HUD_OUTER_WIDTH << 2), HUD_LOWER_Y + (HUD_OUTER_HEIGHT << 2), 
                 G_TX_RENDERTILE, position_of_right_asset << 5, 0 << 5, 1 << 10, 1 << 10);
         }
-        
     }
-
-    //orange drawing
-    if (playerFlags & PlayerHasSecondPortalGun){
-        gDPSetPrimColor(renderState->dl++, 255, 255, 255, 128, 0, 255);
-        if (looked_wall_portalable){
-            position_of_right_asset = (HUD_OUTER_WIDTH*3);
-        }
-        gSPTextureRectangle(renderState->dl++, 
-            HUD_LOWER_X, HUD_LOWER_Y,
-            HUD_LOWER_X + (HUD_OUTER_WIDTH << 2), HUD_LOWER_Y + (HUD_OUTER_HEIGHT << 2), 
-            G_TX_RENDERTILE, position_of_right_asset << 5, 0 << 5, 1 << 10, 1 << 10);
-    }
+    
 
     // both portal guns owned is only time when the last shot portal indicator appears
     if ((playerFlags & PlayerHasSecondPortalGun) && (playerFlags & PlayerHasFirstPortalGun) && last_portal_idx_shot != -1){

--- a/src/scene/hud.h
+++ b/src/scene/hud.h
@@ -3,6 +3,6 @@
 
 #include "../graphics/renderstate.h"
 
-void hudRender(struct RenderState* renderState, int playerFlags, int last_portal_idx_shot, int looked_wall_portalable);
+void hudRender(struct RenderState* renderState, int playerFlags, int last_portal_idx_shot, int looked_wall_portalable_0, int looked_wall_portalable_1);
 
 #endif

--- a/src/scene/scene.c
+++ b/src/scene/scene.c
@@ -175,7 +175,8 @@ void sceneInit(struct Scene* scene) {
 
 
     scene->last_portal_indx_shot=-1;
-    scene->looked_wall_portalable=0;
+    scene->looked_wall_portalable_0=0;
+    scene->looked_wall_portalable_1=0;
 
     scene->freeCameraOffset = gZeroVec;
 
@@ -252,7 +253,7 @@ void sceneRender(struct Scene* scene, struct RenderState* renderState, struct Gr
     gDPSetRenderMode(renderState->dl++, G_RM_OPA_SURF, G_RM_OPA_SURF2);
     gSPGeometryMode(renderState->dl++, G_ZBUFFER | G_LIGHTING | G_CULL_BOTH, G_SHADE);
 
-    hudRender(renderState, scene->player.flags, scene->last_portal_indx_shot, scene->looked_wall_portalable);
+    hudRender(renderState, scene->player.flags, scene->last_portal_indx_shot, scene->looked_wall_portalable_0, scene->looked_wall_portalable_1);
 
     // sceneRenderPerformanceMetrics(scene, renderState, task);
 
@@ -286,10 +287,14 @@ void sceneCheckPortals(struct Scene* scene) {
         soundPlayerPlay(soundsPortalgunShoot[1], 1.0f, 1.0f, NULL, NULL);
     }
 
-    scene->looked_wall_portalable = 0;
+    scene->looked_wall_portalable_0 = 0;
+    scene->looked_wall_portalable_1 = 0;
     if (scene->player.flags & PlayerHasFirstPortalGun){
+        if (sceneFirePortal(scene, &raycastRay, &playerUp, 0, scene->player.body.currentRoom, 1, 1)){
+            scene->looked_wall_portalable_0 = 1;
+        }
         if (sceneFirePortal(scene, &raycastRay, &playerUp, 1, scene->player.body.currentRoom, 1, 1)){
-            scene->looked_wall_portalable = 1;
+            scene->looked_wall_portalable_1 = 1;
         }
     }
 

--- a/src/scene/scene.h
+++ b/src/scene/scene.h
@@ -53,8 +53,9 @@ struct Scene {
     u8 switchCount;
     u8 ballLancherCount;
     u8 ballCatcherCount;
-    int last_portal_indx_shot;
-    int looked_wall_portalable;
+    u8 last_portal_indx_shot;
+    u8 looked_wall_portalable_0;
+    u8 looked_wall_portalable_1;
 };
 
 extern struct Scene gScene;


### PR DESCRIPTION
these are some final tweaks to the HUD:
- when grabbing an object HUD turns white (as in the game)
![grabbing](https://user-images.githubusercontent.com/71656782/222987943-f2a11b82-36d6-44b1-9514-6345ad4634e3.png)

- blue part of HUD indicates that a BLUE portal can be shot (not just any portal)
![only_blue_valid](https://user-images.githubusercontent.com/71656782/222987947-ca5fc1c3-7e00-4cbe-ac61-95aba292a229.png)
- orange part of HUD indicates that an ORANGE portal can be shot (not just any portal)

![only_orange_valid](https://user-images.githubusercontent.com/71656782/222987951-4079a5fc-65ea-4bd9-84f2-ef2e342affe4.png)

- added a "PlayerIsGrabbing" flag to player. 


at this point I think every logic based hud element has been implemented not sure where the asset for the center reticle is (the white dots right in the middle of the HUD), but once we add that as an asset it should be easy to plop that in the middle of the rest of the HUD elements