### PR TITLE
Looking Forward/Backward Functionality

### DIFF
--- a/src/player/player.c
+++ b/src/player/player.c
@@ -501,6 +501,35 @@ void playerUpdate(struct Player* player, struct Transform* cameraTransform) {
             collisionSceneAddDynamicObject(&player->collisionObject);
             collisionObjectUpdateBB(&player->collisionObject);
         }
+
+        //look straight forward
+        if (controllerGetButtonDown(0, U_CBUTTONS)){
+            struct Vector3 lookingForward;
+            vector3Negate(&gForward, &lookingForward);
+            quatMultVector(&player->lookTransform.rotation, &lookingForward, &lookingForward);
+            if (fabsf(lookingForward.y) < 0.999f) {
+                lookingForward.y = 0;
+                quatLook(&lookingForward, &gUp, &player->lookTransform.rotation);
+            }
+        }
+        //look behind
+        if (controllerGetButtonDown(0, D_CBUTTONS)){
+            struct Vector3 lookingForward;
+            vector3Negate(&gForward, &lookingForward);
+            quatMultVector(&player->lookTransform.rotation, &lookingForward, &lookingForward);
+            if (fabsf(lookingForward.y) < 0.999f) {
+                lookingForward.y = 0;
+                quatLook(&lookingForward, &gUp, &player->lookTransform.rotation);
+                //look directly behind
+                struct Quaternion behindRotation;
+                behindRotation.x=(player->lookTransform.rotation.z);
+                behindRotation.y=player->lookTransform.rotation.w;
+                behindRotation.z=(-1.0f*player->lookTransform.rotation.x);
+                behindRotation.w=(-1.0f*player->lookTransform.rotation.y);
+
+                player->lookTransform.rotation = behindRotation;
+            }
+        }
     }
 
     targetVelocity.y = player->body.velocity.y;


### PR DESCRIPTION
the following has been implemented:
- C UP cancels out any pitch the player might have (looks straight)
- C DOWN cancels out any pitch and rotates 180 (looks behind)
- this was implemented with only existing quaternion math operations
- functionality disabled if player is looking directly up or down.