### PR TITLE
Resets Portal Gun State at Level 0

### DIFF
--- a/src/levels/savefile.c
+++ b/src/levels/savefile.c
@@ -17,6 +17,10 @@ void savefileSetFlags(enum SavefileFlags flags) {
     gCurrentSave.flags |= flags;
 }
 
+void savefileUnsetFlags(enum SavefileFlags flags) {
+    gCurrentSave.flags &= ~flags;
+}
+
 int savefileReadFlags(enum SavefileFlags flags) {
     return gCurrentSave.flags & flags;
 }

--- a/src/levels/savefile.h
+++ b/src/levels/savefile.h
@@ -10,6 +10,8 @@ void savefileNew();
 
 void savefileSetFlags(enum SavefileFlags flags);
 
+void savefileUnsetFlags(enum SavefileFlags flags);
+
 int savefileReadFlags(enum SavefileFlags flags);
 
 #endif

--- a/src/player/player.c
+++ b/src/player/player.c
@@ -143,6 +143,12 @@ void playerInit(struct Player* player, struct Location* startLocation, struct Ve
         player->flags |= PlayerHasSecondPortalGun;
     }
 
+    if (gCurrentLevelIndex == 0){
+        player->flags &= ~PlayerHasFirstPortalGun;
+        player->flags &= ~PlayerHasSecondPortalGun;
+        savefileUnsetFlags(SavefileFlagsFirstPortalGun);
+        savefileUnsetFlags(SavefileFlagsFirstPortalGun);
+    }
 
     // player->flags |= PlayerHasFirstPortalGun | PlayerHasSecondPortalGun;
 


### PR DESCRIPTION
This is adds some logic to reset the players portal gun flags when they are initialized at level 0.
Also added functionality to unset a flag in the savefile.c

Fixes #35
