### PR TITLE
Fixes Game Crash On Portal Exit Fizzler Enter

### DIFF
--- a/src/scene/scene.c
+++ b/src/scene/scene.c
@@ -329,13 +329,15 @@ void sceneCheckPortals(struct Scene* scene) {
     }
 
     if (scene->player.body.flags & RigidBodyFizzled) {
-        if (scene->portals[0].flags & PortalFlagsPlayerPortal) {
-            sceneClosePortal(scene, 0);
+        if (!rigidBodyCheckPortals(&scene->player.body)){
+            if (scene->portals[0].flags & PortalFlagsPlayerPortal) {
+                sceneClosePortal(scene, 0);
+            }
+            if (scene->portals[1].flags & PortalFlagsPlayerPortal) {
+                sceneClosePortal(scene, 1);
+            }
+            scene->player.body.flags &= ~RigidBodyFizzled;
         }
-        if (scene->portals[1].flags & PortalFlagsPlayerPortal) {
-            sceneClosePortal(scene, 1);
-        }
-        scene->player.body.flags &= ~RigidBodyFizzled;
     }
 
     int isOpen = collisionSceneIsPortalOpen();

--- a/src/scene/scene.c
+++ b/src/scene/scene.c
@@ -329,7 +329,7 @@ void sceneCheckPortals(struct Scene* scene) {
     }
 
     if (scene->player.body.flags & RigidBodyFizzled) {
-        if (!rigidBodyCheckPortals(&scene->player.body)){
+        if (!(scene->player.body.flags & (RigidBodyIsTouchingPortalA|RigidBodyIsTouchingPortalB|RigidBodyWasTouchingPortalA|RigidBodyWasTouchingPortalB))){
             if (scene->portals[0].flags & PortalFlagsPlayerPortal) {
                 sceneClosePortal(scene, 0);
             }


### PR DESCRIPTION
- only allows fizzler to close portals if the player is not in a portal currently.

Fixes #28