### PR TITLE
Fixed Objects Dissapearing Between Rooms

### DIFF
--- a/src/player/player.c
+++ b/src/player/player.c
@@ -728,11 +728,7 @@ void playerUpdate(struct Player* player, struct Transform* cameraTransform) {
         cameraTransform->position.y += DEAD_OFFSET;
     }
 
-    int prev_room = player->body.currentRoom;
     player->body.currentRoom = worldCheckDoorwayCrossings(&gCurrentLevel->world, &player->lookTransform.position, player->body.currentRoom, doorwayMask);
-    if (playerIsGrabbing(player) && prev_room != player->body.currentRoom){
-        player->grabConstraint.object->body->currentRoom = player->body.currentRoom;
-    }
     dynamicSceneSetRoomFlags(player->dynamicId, ROOM_FLAG_FROM_INDEX(player->body.currentRoom));
 
     float startTime = 0.0f;

--- a/src/player/player.c
+++ b/src/player/player.c
@@ -728,8 +728,11 @@ void playerUpdate(struct Player* player, struct Transform* cameraTransform) {
         cameraTransform->position.y += DEAD_OFFSET;
     }
 
+    int prev_room = player->body.currentRoom;
     player->body.currentRoom = worldCheckDoorwayCrossings(&gCurrentLevel->world, &player->lookTransform.position, player->body.currentRoom, doorwayMask);
-
+    if (playerIsGrabbing(player) && prev_room != player->body.currentRoom){
+        player->grabConstraint.object->body->currentRoom = player->body.currentRoom;
+    }
     dynamicSceneSetRoomFlags(player->dynamicId, ROOM_FLAG_FROM_INDEX(player->body.currentRoom));
 
     float startTime = 0.0f;


### PR DESCRIPTION
previously if the player walked with a decore object to a new room within a level, the object would dissapear (because it was no longer set to the correct currentRoom). This can be seen in test chamber 0 with the radio for example.

- this is a simple fix to change the currentRoom of a grabbed object to the players room if the player walks through a doorway.