### PR TITLE
Adds Movement to Portal Gun

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,13 @@ Where `/home/james/Blender/blender-2.93.1-linux-x64` is the folder where Blender
 - [ ] Portal not rendering recursively sometimes
 - [ ] Correct elevator timing
 - [ ] Presort portal gun polygon order
-- [ ] Portal gun movement with player movement/shooting #19
 - [ ] Camera shake
 - [ ] Adding a menu to game #47
 - [ ] Adding y-axis/x-axis inverting options #55
 - [ ] Adding loading notice between levels #45
 - [ ] Vertex lighting #39
 - [ ] Multi controller support #23
+- [x] Portal gun movement with player movement/shooting #19
 
 ## Current New Sounds TODO List
 - [ ] Fast flying air whoosh sound

--- a/src/physics/contact_solver.c
+++ b/src/physics/contact_solver.c
@@ -322,7 +322,7 @@ void contactSolverIterateConstraints(struct ContactSolver* contactSolver) {
 	struct PointConstraint* prev = NULL;
 
 	while (curr) {
-		if (!pointConstraintMoveToPoint(curr->object, &curr->targetPos, curr->maxPosImpulse)) {
+		if (!pointConstraintMoveToPoint(curr->object, &curr->targetPos, curr->maxPosImpulse, curr->teleportOnBreak, curr->movementScaleFactor)) {
 			struct PointConstraint* next = curr->nextConstraint;
 
 			if (prev) {

--- a/src/physics/point_constraint.h
+++ b/src/physics/point_constraint.h
@@ -11,12 +11,14 @@ struct PointConstraint {
     struct Quaternion targetRot;
     float maxPosImpulse;
     float maxRotImpulse;
+    int teleportOnBreak;
+    float movementScaleFactor;
 };
 
-void pointConstraintInit(struct PointConstraint* constraint, struct CollisionObject* object, float maxPosImpulse, float maxRotImpulse);
+void pointConstraintInit(struct PointConstraint* constraint, struct CollisionObject* object, float maxPosImpulse, float maxRotImpulse, int teleportOnBreak, float movementScaleFactor);
 void pointConstraintUpdateTarget(struct PointConstraint* constraint, struct Vector3* worldPoint, struct Quaternion* worldRotation);
 
-int pointConstraintMoveToPoint(struct CollisionObject* object, struct Vector3* worldPoint, float maxImpulse);
+int pointConstraintMoveToPoint(struct CollisionObject* object, struct Vector3* worldPoint, float maxImpulse, int teleportOnBreak, float movementScaleFactor);
 void pointConstraintRotateTo(struct RigidBody* rigidBody, struct Quaternion* worldRotation, float maxImpulse);
 
 #endif

--- a/src/player/player.h
+++ b/src/player/player.h
@@ -27,6 +27,7 @@ enum PlayerFlags {
     PlayerJustLanded = (1 << 8),
     PlayerJustSelect = (1 << 9),
     PlayerJustDeniedSelect = (1 << 10),
+    PlayerJustShotPortalGun = (1 << 11),
 };
 
 struct Player {
@@ -38,6 +39,7 @@ struct Player {
     short grabbingThroughPortal;
     short dynamicId;
     struct PointConstraint grabConstraint;
+    struct PointConstraint gunConstraint;
     float pitchVelocity;
     float yawVelocity;
     enum PlayerFlags flags;
@@ -49,7 +51,7 @@ struct Player {
     int currentFoot; //left=0, right=1
 };
 
-void playerInit(struct Player* player, struct Location* startLocation, struct Vector3* velocity);
+void playerInit(struct Player* player, struct Location* startLocation, struct Vector3* velocity, struct CollisionObject* portalGunObject);
 void playerUpdate(struct Player* player, struct Transform* cameraTransform);
 
 void playerGetMoveBasis(struct Transform* transform, struct Vector3* forward, struct Vector3* right);

--- a/src/scene/portal_gun.c
+++ b/src/scene/portal_gun.c
@@ -1,0 +1,78 @@
+#include "portal_gun.h"
+
+#include "../physics/collision_scene.h"
+#include "../physics/collision_cylinder.h"
+#include "models/models.h"
+
+struct Vector2 gGunColliderEdgeVectors[] = {
+    {0.0f, 1.0f},
+    {0.707f, 0.707f},
+    {1.0f, 0.0f},
+    {0.707f, -0.707f},
+};
+
+struct CollisionQuad gGunColliderFaces[8];
+
+struct CollisionCylinder gGunCollider = {
+    0.05f,
+    0.1f,
+    gGunColliderEdgeVectors,
+    sizeof(gGunColliderEdgeVectors) / sizeof(*gGunColliderEdgeVectors),
+    gGunColliderFaces,
+};
+
+struct ColliderTypeData gGunColliderData = {
+    CollisionShapeTypeCylinder,
+    &gGunCollider,
+    0.0f,
+    0.6f,
+    &gCollisionCylinderCallbacks,
+};
+
+void portalGunInit(struct PortalGun* portalGun, struct Transform* at){
+    collisionObjectInit(&portalGun->collisionObject, &gGunColliderData, &portalGun->rigidBody, 1.0f, 0);
+    collisionSceneAddDynamicObject(&portalGun->collisionObject);
+    portalGun->rigidBody.transform = *at;
+    portalGun->rigidBody.transform.scale = gOneVec;
+    portalGun->rigidBody.currentRoom = 0;
+    portalGun->rigidBody.velocity = gZeroVec;
+    portalGun->rigidBody.angularVelocity = gZeroVec;
+    portalGun->dynamicId = dynamicSceneAdd(portalGun, portalGunDummyRender, &portalGun->rigidBody.transform.position, 0.05f);
+    portalGun->portalGunVisible = 0;
+
+    collisionObjectUpdateBB(&portalGun->collisionObject);
+    dynamicSceneSetRoomFlags(portalGun->dynamicId, ROOM_FLAG_FROM_INDEX(portalGun->rigidBody.currentRoom));
+
+}
+
+void portalGunDummyRender(void* data, struct DynamicRenderDataList* renderList, struct RenderState* renderState){
+    return;
+}
+
+void portalGunRenderReal(struct PortalGun* portalGun, struct RenderState* renderState){
+    if (portalGun->portalGunVisible){
+        portalGun->rigidBody.transform.scale = gOneVec;
+        Mtx* matrix = renderStateRequestMatrices(renderState, 1);
+
+        if (!matrix) {
+            return;
+        }
+
+        transformToMatrixL(&portalGun->rigidBody.transform, matrix, SCENE_SCALE);
+        gSPMatrix(renderState->dl++, matrix, G_MTX_MODELVIEW | G_MTX_PUSH | G_MTX_MUL);
+        gSPDisplayList(renderState->dl++, v_portal_gun_gfx);
+        gSPPopMatrix(renderState->dl++, G_MTX_MODELVIEW);
+    }
+}
+
+
+
+void portalGunUpdate(struct PortalGun* portalGun, struct Player* player){
+    if (player->flags & (PlayerHasFirstPortalGun | PlayerHasSecondPortalGun)){
+        portalGun->portalGunVisible = 1;
+    }
+    else{
+        portalGun->portalGunVisible = 0;
+    }
+    dynamicSceneSetRoomFlags(portalGun->dynamicId, ROOM_FLAG_FROM_INDEX(portalGun->rigidBody.currentRoom));
+}

--- a/src/scene/portal_gun.h
+++ b/src/scene/portal_gun.h
@@ -1,0 +1,24 @@
+#ifndef __PORTAL_GUN_H__
+#define __PORTAL_GUN_H__
+
+#include "../physics/collision_object.h"
+#include "../math/transform.h"
+#include "../graphics/renderstate.h"
+#include "../physics/rigid_body.h"
+#include "../physics/collision_object.h"
+#include "../scene/dynamic_scene.h"
+#include "../player/player.h"
+
+struct PortalGun {
+    struct CollisionObject collisionObject;
+    struct RigidBody rigidBody;
+    int portalGunVisible;
+    short dynamicId;
+};
+
+void portalGunInit(struct PortalGun* portalGun, struct Transform* at);
+void portalGunDummyRender(void* data, struct DynamicRenderDataList* renderList, struct RenderState* renderState);
+void portalGunUpdate(struct PortalGun* portalGun, struct Player* player);
+void portalGunRenderReal(struct PortalGun* portalGun, struct RenderState* renderState);
+
+#endif

--- a/src/scene/scene.h
+++ b/src/scene/scene.h
@@ -20,10 +20,12 @@
 #include "switch.h"
 #include "ball_launcher.h"
 #include "ball_catcher.h"
+#include "portal_gun.h"
 
 struct Scene {
     struct Camera camera;
     struct Player player;
+    struct PortalGun portalGun;
     struct Portal portals[2];
     struct Button* buttons;
     struct DecorObject** decor;


### PR DESCRIPTION
- The portal gun now has its own .c/.h files
- the portal gun is a struct containing a `CollisionObject` and `RigidBody`
- portal gun `CollisionObject` is set as a permanent player point constraint
- portal gun also moves while shooting
- video attached of it working
- was tested on N64 hardware no game breaking issues.

https://user-images.githubusercontent.com/71656782/227679073-aafcabd5-76ea-40ca-8ea2-6d3a8a9ac4c3.mp4

Fixes #19 