### PR TITLE
Simply fixed grabbing controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,11 +132,11 @@ Where `/home/james/Blender/blender-2.93.1-linux-x64` is the folder where Blender
 - [ ] Two wall portals next to eachother can be used to clip any object out of any level by pushing it into corner, then dropping. 
 - [ ] Glass can be walked through from one side on multiple levels (0,1,4,...)
 - [ ] Passing into a ceiling portal can sometimes mess with the player rotation
-- [ ] Can shoot portals through decor objects
-- [ ] Can shoot portals while holding an object
 - [ ] Can shoot portals, and walk through signage
 - [ ] Chell animation problem (fixed itself, investigate)
 - [ ] Can place portals on ground after final fizzler on all levels
 - [ ] Door at end of room 2, chamber 10 isnt rendered properly
 - [ ] various visual glitches when running NTSC on PAL console #65
 - [ ] various visual glitches when running PAL on NTSC console #65
+- [x] Can shoot portals while holding an object
+

--- a/src/main.c
+++ b/src/main.c
@@ -161,7 +161,7 @@ static void gameProc(void* arg) {
     contactSolverInit(&gContactSolver);
     portalSurfaceCleanupQueueInit();
     savefileNew();
-    levelLoad(6);
+    levelLoad(2);
     cutsceneRunnerReset();
     controllersInit();
     initAudio(fps);

--- a/src/scene/scene.c
+++ b/src/scene/scene.c
@@ -279,16 +279,20 @@ void sceneCheckPortals(struct Scene* scene) {
     quatMultVector(&scene->player.lookTransform.rotation, &raycastRay.dir, &raycastRay.dir);
     quatMultVector(&scene->player.lookTransform.rotation, &gUp, &playerUp);
 
-    if (controllerGetButtonDown(0, Z_TRIG) && (scene->player.flags & PlayerHasSecondPortalGun)) {
+    if (controllerGetButtonDown(0, Z_TRIG) && (scene->player.flags & PlayerHasSecondPortalGun) && !playerIsGrabbing(&scene->player)) {
         sceneFirePortal(scene, &raycastRay, &playerUp, 0, scene->player.body.currentRoom, 1, 0);
         scene->last_portal_indx_shot=0;
         soundPlayerPlay(soundsPortalgunShoot[0], 1.0f, 1.0f, NULL, NULL);
     }
 
-    if (controllerGetButtonDown(0, R_TRIG | L_TRIG) && (scene->player.flags & PlayerHasFirstPortalGun)) {
+    if (controllerGetButtonDown(0, R_TRIG | L_TRIG) && (scene->player.flags & PlayerHasFirstPortalGun) && !playerIsGrabbing(&scene->player)) {
         sceneFirePortal(scene, &raycastRay, &playerUp, 1, scene->player.body.currentRoom, 1, 0);
         scene->last_portal_indx_shot=1;
         soundPlayerPlay(soundsPortalgunShoot[1], 1.0f, 1.0f, NULL, NULL);
+    }
+
+    if (controllerGetButtonDown(0, R_TRIG | L_TRIG | Z_TRIG) && playerIsGrabbing(&scene->player)){
+        playerSetGrabbing(&scene->player, NULL);
     }
 
 


### PR DESCRIPTION
- the player shouldnt be able to shoot a portal while grabbing an object (as in game)
- if the player does shoot while grabbing an object then the object is dropped (as in game)
- also turns out you CAN shoot through decor objects in the game lol