### PR TITLE
Portal visual fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Where `/home/james/Blender/blender-2.93.1-linux-x64` is the folder where Blender
 - [ ] player can clip through back of elevator by jumping and strafeing at the back corners while inside.
 - [ ] Player can strap themselves in chamber 5 by following instructions issue #75
 - [ ] Any grabbable object can be clipped through level by wall/floor portals method.
+- [ ] Two wall portals can be placed on top of eachother in certain instances if on the same surface
 - [ ] Two wall portals next to eachother can be used to clip any object out of any level by pushing it into corner, then dropping. 
 - [ ] Glass can be walked through from one side on multiple levels (0,1,4,...)
 - [ ] Passing into a ceiling portal can sometimes mess with the player rotation

--- a/src/graphics/screen_clipper.c
+++ b/src/graphics/screen_clipper.c
@@ -137,7 +137,7 @@ void screenClipperBoundingPoints(struct ScreenClipper* clipper, struct Vector3* 
                 next->x += PIXEL_EXPAND_COUNT;
             } else {
                 curr->x += PIXEL_EXPAND_COUNT;
-                next->y -= PIXEL_EXPAND_COUNT;
+                next->x -= PIXEL_EXPAND_COUNT;
             }
         } else {
             if (curr->y < next->y) {

--- a/src/scene/portal_surface.h
+++ b/src/scene/portal_surface.h
@@ -59,6 +59,7 @@ void portalSurfaceCleanupQueueInit();
 
 int portalSurfaceAreBothOnSameSurface();
 int portalSurfaceShouldSwapOrder(int portalToMove);
+void portalSurfacePreSwap(int portalToMove);
 int portalSurfaceStaticIndexForReplacement(int portalIndex);
 
 int portalSurfaceIsInside(struct PortalSurface* surface, struct Transform* portalAt);

--- a/src/scene/render_plan.c
+++ b/src/scene/render_plan.c
@@ -197,16 +197,6 @@ int renderPlanPortal(struct RenderPlan* renderPlan, struct Scene* scene, struct 
     next->minY = MAX(next->minY, current->minY);
     next->maxY = MIN(next->maxY, current->maxY);
 
-    struct RenderProps* prevSibling = prevSiblingPtr ? *prevSiblingPtr : NULL;
-
-    if (prevSibling) {
-        if (next->minX < prevSibling->minX) {
-            next->maxX = MIN(next->maxX, prevSibling->minX);
-        } else {
-            next->minX = MAX(next->minX, prevSibling->maxX);
-        }
-    }
-
     if (next->minX >= next->maxX || next->minY >= next->maxY) {
         return 0;
     }

--- a/src/scene/render_plan.c
+++ b/src/scene/render_plan.c
@@ -197,6 +197,75 @@ int renderPlanPortal(struct RenderPlan* renderPlan, struct Scene* scene, struct 
     next->minY = MAX(next->minY, current->minY);
     next->maxY = MIN(next->maxY, current->maxY);
 
+    struct RenderProps* prevSibling = prevSiblingPtr ? *prevSiblingPtr : NULL;
+
+    if (prevSibling) {
+        int topDiff = 0;
+        int bottomDiff = 0;
+        int leftDiff = 0;
+        int rightDiff = 0;
+
+        // if top left overlapping
+        if ((next->minX > prevSibling->minX) && (next->minX < prevSibling->maxX) && (next->minY > prevSibling->minY) && (next->minY < prevSibling->maxY)){
+            topDiff = MAX(abs(prevSibling->maxY-next->minY), topDiff);
+            leftDiff = MAX(abs(prevSibling->maxX-next->minX), leftDiff);
+        }
+
+        // if top right overlapping
+        if ((next->maxX > prevSibling->minX) && (next->maxX < prevSibling->maxX) && (next->minY > prevSibling->minY) && (next->minY < prevSibling->maxY)){
+            topDiff = MAX(abs(prevSibling->maxY-next->minY), topDiff);
+            rightDiff = MAX(abs(next->maxX -prevSibling->minX), rightDiff);
+        }
+
+        // if bottom left overlapping
+        if ((next->minX > prevSibling->minX) && (next->minX < prevSibling->maxX) && (next->maxY > prevSibling->minY) && (next->maxY < prevSibling->maxY)){
+            bottomDiff = MAX(abs(next->maxY-prevSibling->minY), bottomDiff);
+            leftDiff = MAX(abs(prevSibling->maxX-next->minX), leftDiff);
+        }
+
+        // if bottom right overlapping
+        if ((next->maxX > prevSibling->minX) && (next->maxX < prevSibling->maxX) && (next->maxY > prevSibling->minY) && (next->maxY < prevSibling->maxY)){
+            bottomDiff = MAX(abs(next->maxY-prevSibling->minY), bottomDiff);
+            rightDiff = MAX(abs(next->maxX -prevSibling->minX), rightDiff);
+        }
+
+        //shouldnt draw at all if fully overlapped
+        if (rightDiff && leftDiff && topDiff && bottomDiff){
+            return 0;
+        }
+        //cut nothing if no overlap
+        else if (!rightDiff && !leftDiff && !topDiff && !bottomDiff){
+            //do nothing
+        }
+        //should only cut out top portion
+        else if (rightDiff && leftDiff && topDiff && !bottomDiff){
+            next->minY += topDiff;
+        }
+        //should only cut out bottom portion
+        else if (rightDiff && leftDiff && !topDiff && bottomDiff){
+            next->maxY -= bottomDiff;
+        }
+        //should only cut out right portion
+        else if (rightDiff && !leftDiff && topDiff && bottomDiff){
+            next->maxX -= rightDiff;
+        }
+        //should only cut out left portion
+        else if (!rightDiff && leftDiff && topDiff && bottomDiff){
+            next->minX += leftDiff;
+        }
+        // only one corner is overlapping so cut the larger side
+        else{
+            if (MAX(rightDiff, leftDiff) > MAX(topDiff, bottomDiff)){
+                next->minY += topDiff;
+                next->maxY -= bottomDiff;
+            }
+            else{
+                next->minX += leftDiff;
+                next->maxX -= rightDiff;
+            }
+        }
+    }
+
     if (next->minX >= next->maxX || next->minY >= next->maxY) {
         return 0;
     }


### PR DESCRIPTION
- fixes "holes" being left behind (fixed in portal.c and making use of some unused functions)
- fixes portals in same x position (aligned vertically) not being displayed properly (fixed in render_plan.c)
- fixes a hardware only crash where two portals being placed at roughly the same time would crash the game
- found a bug (unfixed)(was present before as well) where two portals can be placed on top of eachother in certain instances. added to bug TODO list.

Fixes https://github.com/lambertjamesd/portal64/issues/53

Before holes being left behind bug:

https://user-images.githubusercontent.com/71656782/229311364-bcb713fa-2d68-40a0-9030-601ceeb51dca.mp4

Before aligned vertically on screen bug:

https://user-images.githubusercontent.com/71656782/229311370-31cbc87e-5749-48d7-b84f-ca149cc71323.mp4

holes fixed:

https://user-images.githubusercontent.com/71656782/229311379-f3a7e29b-5c8f-487c-84f7-2f99fece80f4.mp4

aligned vertically fixed:

https://user-images.githubusercontent.com/71656782/229311381-231f2e0b-6413-4889-bbfe-63dc9cc0a9a7.mp4


