### PR TITLE
Adding a License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 James D. Lambert
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Fixes #5

I've looked around a lot at similar types of de-makes/mods and the general consensus seems to use either: 
`MIT License`
or
`GPL2.0 or 3.0`

Feel free to shoot back any thoughts/revisions, we might even be able to add an exclusion to the MIT license reguarding anything in the `assets/` folder

Here are a list of examples:

GAME REMAKES:
https://github.com/jonof/jfduke3d - GPL2.0
https://sourceforge.net/p/ufoai/code/ci/master/tree/ - GPL2.0 https://github.com/hasseily/Deathlord-Relorded - GPL3.0 https://github.com/smbx/smbx-legacy-source - MIT
https://github.com/b3dgs/warcraft-remake - GPLv3.0 https://github.com/LazyDuchess/OpenTS2 - Mozilla v2.0 https://github.com/JohanLi/uncharted-waters-2 - MIT License https://github.com/undefined-darkness/open-horizon - MIT https://github.com/ChariotEngine/Chariot - MIT
https://github.com/sandsmark/freeaoe - GPL3.0
https://github.com/SFTtech/openage - GPLv3.0
https://github.com/bjaraujo/Bombermaaan - GPLv3.0
https://github.com/GlPortal/glPortal - zlib license https://github.com/UnknownShadow200/ClassiCube - various licenses https://github.com/fogleman/Craft - MIT
https://github.com/PistonDevelopers/hematite - MIT https://github.com/MovingBlocks/Terasology - Apache 2.0 https://github.com/danicat/pacgo - MIT
https://github.com/Novum/vkQuake - GPLv2.0
https://github.com/Triang3l/WebQuake/blob/master/GNU.md - GPL v2.0

OTHER GAME MODS
https://github.com/ForestryMC/ForestryMC - LGPLv3.0 https://github.com/AppliedEnergistics/Applied-Energistics-2 - LGPLv3.0 https://github.com/xCollateral/VulkanMod - LGPLv3.0

https://github.com/miere43/auto-use-spell-tomes - MIT https://github.com/McJtyMods/RFTools - MIT
https://github.com/mlthelama/SkyrimCharacterSheet/blob/main/LICENSE - MIT https://github.com/alexsylex/CompassNavigationOverhaul/blob/main/LICENSE - MIT https://github.com/mort65/mark-of-arkay - MIT

https://github.com/SleepyTrousers/EnderIO - The Unlicense https://gitlab.com/thor12022/HardcoreWither - BSD 3-Clause