### PR TITLE
Force Places Auto Portals on Conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ Where `/home/james/Blender/blender-2.93.1-linux-x64` is the folder where Blender
 <br />
 
 ## Current New Feature TODO List
-- [ ] force placing auto portals when there is a conflict
 - [ ] rotate auto uv
 - [ ] disable portal surfaces manually on some surfaces
 - [ ] Portal not rendering recursively sometimes
@@ -135,6 +134,7 @@ Where `/home/james/Blender/blender-2.93.1-linux-x64` is the folder where Blender
 - [ ] Adding loading notice between levels #45
 - [ ] Vertex lighting #39
 - [ ] Multi controller support #23
+- [x] force placing auto portals when there is a conflict
 - [x] Camera shake
 - [x] Portal gun movement with player movement/shooting #19
 

--- a/src/scene/scene.c
+++ b/src/scene/scene.c
@@ -175,6 +175,7 @@ void sceneInit(struct Scene* scene) {
     scene->last_portal_indx_shot=-1;
     scene->looked_wall_portalable_0=0;
     scene->looked_wall_portalable_1=0;
+    scene->continuouslyAttemptingPortalOpen=0;
 
     scene->freeCameraOffset = gZeroVec;
 
@@ -260,6 +261,9 @@ void sceneCheckPortals(struct Scene* scene) {
 
     int hasBlue = (scene->player.flags & PlayerHasFirstPortalGun) != 0;
     int hasOrange = (scene->player.flags & PlayerHasSecondPortalGun) != 0;
+    if (scene->continuouslyAttemptingPortalOpen){
+        sceneFirePortal(scene, &scene->savedPortal.ray, &scene->savedPortal.transformUp, scene->savedPortal.portalIndex, scene->savedPortal.roomIndex, 0, 0);
+    }
 
     if (fireOrange && hasOrange && !playerIsGrabbing(&scene->player)) {
         sceneFirePortal(scene, &raycastRay, &playerUp, 0, scene->player.body.currentRoom, 1, 0);
@@ -310,7 +314,6 @@ void sceneCheckPortals(struct Scene* scene) {
 
     if (scene->player.flags & PlayerHasFirstPortalGun){
         if (sceneFirePortal(scene, &raycastRay, &playerUp, 0, scene->player.body.currentRoom, 1, 1)){
-            
             scene->looked_wall_portalable_0 = 1;
         }
         if (sceneFirePortal(scene, &raycastRay, &playerUp, 1, scene->player.body.currentRoom, 1, 1)){
@@ -726,7 +729,19 @@ int sceneFirePortal(struct Scene* scene, struct Ray* ray, struct Vector3* player
         quatLook(&hitDirection, &upDir, &portalLocation.rotation);
     }
 
-    return sceneOpenPortal(scene, &portalLocation, relativeIndex, portalIndex, mappingRange, hit.object, hit.roomIndex, fromPlayer, just_checking);
+    if (!sceneOpenPortal(scene, &portalLocation, relativeIndex, portalIndex, mappingRange, hit.object, hit.roomIndex, fromPlayer, just_checking) && !fromPlayer){
+        sceneClosePortal(scene, 1-portalIndex);
+        scene->continuouslyAttemptingPortalOpen = 1;
+        scene->savedPortal.portalIndex = portalIndex;
+        scene->savedPortal.ray = *ray;
+        scene->savedPortal.roomIndex = roomIndex;
+        scene->savedPortal.transformUp = *playerUp;
+        return 0;
+    }
+    if (!fromPlayer){
+        scene->continuouslyAttemptingPortalOpen = 0;
+    }
+    return 1;
 }
 
 void sceneClosePortal(struct Scene* scene, int portalIndex) {

--- a/src/scene/scene.h
+++ b/src/scene/scene.h
@@ -22,6 +22,13 @@
 #include "ball_catcher.h"
 #include "portal_gun.h"
 
+struct SavedPortal{
+    struct Ray ray;
+    struct Vector3 transformUp;
+    int portalIndex;
+    int roomIndex;
+};
+
 struct Scene {
     struct Camera camera;
     struct Player player;
@@ -41,6 +48,7 @@ struct Scene {
     struct CollisionObject* dynamicColliders;
     struct BallLauncher* ballLaunchers;
     struct BallCatcher* ballCatchers;
+    struct SavedPortal savedPortal;
     OSTime cpuTime;
     OSTime lastFrameStart;
     OSTime lastFrameTime;
@@ -58,6 +66,7 @@ struct Scene {
     u8 last_portal_indx_shot;
     u8 looked_wall_portalable_0;
     u8 looked_wall_portalable_1;
+    u8 continuouslyAttemptingPortalOpen;
 };
 
 extern struct Scene gScene;


### PR DESCRIPTION
Fixes #141
- this fix forces an autoportal to be placed if there is a conflict.
- if there is a conflict when an auto portal is attempted to be placed it will:
1. close the other portal
2. save a copy of the parameters to the `sceneFirePortal` function in new `SavedPortal` struct
3. `continuouslyAttemptingPortalOpen` == 1
4. attempt to open the same portal once every single `sceneUpdate` call
- once it finally can open the portal it will set `continuouslyAttemptingPortalOpen` back to 0


https://user-images.githubusercontent.com/71656782/235384957-b4b20adf-488c-48ec-8d9a-c43645196ede.mp4

