### PR TITLE
Pellet Kill Freeze Fix

### DIFF
--- a/src/scene/scene.c
+++ b/src/scene/scene.c
@@ -728,7 +728,7 @@ int sceneFirePortal(struct Scene* scene, struct Ray* ray, struct Vector3* player
 }
 
 void sceneClosePortal(struct Scene* scene, int portalIndex) {
-    if (scene->player.body.flags & (RigidBodyIsTouchingPortalA|RigidBodyIsTouchingPortalB|RigidBodyWasTouchingPortalA|RigidBodyWasTouchingPortalB)){
+    if (scene->player.body.flags & (RigidBodyIsTouchingPortalA|RigidBodyIsTouchingPortalB|RigidBodyWasTouchingPortalA|RigidBodyWasTouchingPortalB|RigidBodyFlagsCrossedPortal0|RigidBodyFlagsCrossedPortal1)){
         return;
     } 
     else if (gCollisionScene.portalTransforms[portalIndex]) {

--- a/src/scene/scene.c
+++ b/src/scene/scene.c
@@ -319,15 +319,13 @@ void sceneCheckPortals(struct Scene* scene) {
     }
 
     if (scene->player.body.flags & RigidBodyFizzled) {
-        if (!(scene->player.body.flags & (RigidBodyIsTouchingPortalA|RigidBodyIsTouchingPortalB|RigidBodyWasTouchingPortalA|RigidBodyWasTouchingPortalB))){
-            if (scene->portals[0].flags & PortalFlagsPlayerPortal) {
-                sceneClosePortal(scene, 0);
-            }
-            if (scene->portals[1].flags & PortalFlagsPlayerPortal) {
-                sceneClosePortal(scene, 1);
-            }
-            scene->player.body.flags &= ~RigidBodyFizzled;
+        if (scene->portals[0].flags & PortalFlagsPlayerPortal) {
+            sceneClosePortal(scene, 0);
         }
+        if (scene->portals[1].flags & PortalFlagsPlayerPortal) {
+            sceneClosePortal(scene, 1);
+        }
+        scene->player.body.flags &= ~RigidBodyFizzled;
     }
 
     int isOpen = collisionSceneIsPortalOpen();
@@ -730,11 +728,15 @@ int sceneFirePortal(struct Scene* scene, struct Ray* ray, struct Vector3* player
 }
 
 void sceneClosePortal(struct Scene* scene, int portalIndex) {
-    if (gCollisionScene.portalTransforms[portalIndex]) {
+    if (scene->player.body.flags & (RigidBodyIsTouchingPortalA|RigidBodyIsTouchingPortalB|RigidBodyWasTouchingPortalA|RigidBodyWasTouchingPortalB)){
+        return;
+    } 
+    else if (gCollisionScene.portalTransforms[portalIndex]) {
         soundPlayerPlay(soundsPortalFizzle, 1.0f, 1.0f, &gCollisionScene.portalTransforms[portalIndex]->position, &gZeroVec);
         gCollisionScene.portalTransforms[portalIndex] = NULL;
         scene->portals[portalIndex].flags |= PortalFlagsNeedsNewHole;
         scene->portals[portalIndex].portalSurfaceIndex = -1;
         scene->portals[portalIndex].transformIndex = NO_TRANSFORM_INDEX;
     }
+    return;
 }


### PR DESCRIPTION
- game would freeze previously when player died in or near portal (because the portal would close with player still in it)
- moved the player touching check to be inside of the `sceneClosePortal` function.
- game no longer freezes when killed within a portal.

Fixes #108

[Screencast from 04-30-2023 09:31:11 PM.webm](https://user-images.githubusercontent.com/71656782/235393338-c2dfdd59-9ad8-4372-8d7a-f9cc74646186.webm)

