### PR TITLE
Player Contact Freeze Fix

### DIFF
--- a/src/physics/collision_scene.c
+++ b/src/physics/collision_scene.c
@@ -498,6 +498,10 @@ void dynamicBroadphaseSort(union DynamicBroadphaseEdge* edges, union DynamicBroa
 }
 
 void collisionObjectCollidePairMixed(struct CollisionObject* a, struct Vector3* aPrevPos, struct Box3D* sweptA, struct CollisionObject* b, struct Vector3* bPrevPos, struct Box3D* sweptB, struct ContactSolver* contactSolver) {
+    if (a->body->flags & RigidBodyIsPlayer && b->body->flags & RigidBodyFlagsGrabbable){
+        return;
+    }
+
     if (a->manifoldIds & b->manifoldIds) {
         collisionObjectCollideTwoObjects(a, b, contactSolver);
     } else {

--- a/src/physics/collision_scene.c
+++ b/src/physics/collision_scene.c
@@ -498,10 +498,6 @@ void dynamicBroadphaseSort(union DynamicBroadphaseEdge* edges, union DynamicBroa
 }
 
 void collisionObjectCollidePairMixed(struct CollisionObject* a, struct Vector3* aPrevPos, struct Box3D* sweptA, struct CollisionObject* b, struct Vector3* bPrevPos, struct Box3D* sweptB, struct ContactSolver* contactSolver) {
-    if (a->body->flags & RigidBodyIsPlayer && b->body->flags & RigidBodyFlagsGrabbable){
-        return;
-    }
-
     if (a->manifoldIds & b->manifoldIds) {
         collisionObjectCollideTwoObjects(a, b, contactSolver);
     } else {

--- a/src/player/player.c
+++ b/src/player/player.c
@@ -210,6 +210,11 @@ void playerHandleCollision(struct Player* player) {
             // objects being grabbed by the player shouldn't push the player
             continue;
         }
+
+        if (contact->shapeB->body->flags & RigidBodyFlagsGrabbable && contact->shapeA->body->flags & RigidBodyIsPlayer) {
+            // grabbable objects shouldnt push the player
+            continue;
+        }
         
         if (offset != 0.0f) {
             vector3AddScaled(
@@ -824,10 +829,15 @@ void playerUpdate(struct Player* player, struct Transform* cameraTransform) {
 
 void playerSerialize(struct Serializer* serializer, SerializeAction action, struct Player* player) {
     action(serializer, &player->lookTransform, sizeof(struct PartialTransform));
+    action(serializer, &player->body.velocity, sizeof(player->body.velocity));
+    action(serializer, &player->flags, sizeof(player->flags));
 }
 
 void playerDeserialize(struct Serializer* serializer, struct Player* player) {
     serializeRead(serializer, &player->lookTransform, sizeof(struct PartialTransform));
     player->body.transform.position = player->lookTransform.position;
     player->body.velocity = gZeroVec;
+
+    serializeRead(serializer, &player->body.velocity, sizeof(player->body.velocity));
+    serializeRead(serializer, &player->flags, sizeof(player->flags));
 }


### PR DESCRIPTION
- player producing contact on grabable objects disabled
- grabbable objects producing contact on player has been preserved
- player no longer gets pushed into ground by objects
- video attached

Fixes #136

https://user-images.githubusercontent.com/71656782/236539275-84f6572a-72a5-472f-858f-a3b7ae7f9d01.mp4

