### PR TITLE
Force luac5.4 Compile

### DIFF
--- a/skelatool64/makefile
+++ b/skelatool64/makefile
@@ -20,7 +20,7 @@ default: skeletool64
 
 build/lua/%.o: lua/%.lua
 	@mkdir -p $(@D)
-	luac -o $(@:%.o=%.out) $<
+	luac5.4 -o $(@:%.o=%.out) $<
 	ld -r -b binary -o $@ $(@:%.o=%.out)
 
 build/%.o: %.cpp


### PR DESCRIPTION
one line change in makefile for skeletool, simply requires that user use luac5.4 just incase they have multiple luac/lua versions.