### PR TITLE
HUD Conforms to Console Version of Game

### DIFF
--- a/src/scene/hud.c
+++ b/src/scene/hud.c
@@ -74,22 +74,22 @@ void hudRender(struct RenderState* renderState, struct Player* player, int last_
         if (player->flags & PlayerHasFirstPortalGun){
             gDPSetPrimColor(renderState->dl++, 255, 255, 0, 128, 255, 255);
             if (looked_wall_portalable_1){
-                position_of_left_asset = (HUD_OUTER_WIDTH*2);
+                position_of_right_asset = (HUD_OUTER_WIDTH*3);
             }
             gSPTextureRectangle(renderState->dl++, 
-                HUD_UPPER_X, HUD_UPPER_Y,
-                HUD_UPPER_X + (HUD_OUTER_WIDTH << 2), HUD_UPPER_Y + (HUD_OUTER_HEIGHT << 2), 
-                G_TX_RENDERTILE, position_of_left_asset << 5, 0 << 5, 1 << 10, 1 << 10);
+                HUD_LOWER_X, HUD_LOWER_Y,
+                HUD_LOWER_X + (HUD_OUTER_WIDTH << 2), HUD_LOWER_Y + (HUD_OUTER_HEIGHT << 2), 
+                G_TX_RENDERTILE, position_of_right_asset << 5, 0 << 5, 1 << 10, 1 << 10);
             
             // if the player has the first gun but not second both left and right are blue
             if (!(player->flags & PlayerHasSecondPortalGun)){
                 if (looked_wall_portalable_1){
-                    position_of_right_asset = (HUD_OUTER_WIDTH*3);
+                    position_of_left_asset = (HUD_OUTER_WIDTH*2);
                 }   
                 gSPTextureRectangle(renderState->dl++, 
-                    HUD_LOWER_X, HUD_LOWER_Y,
-                    HUD_LOWER_X + (HUD_OUTER_WIDTH << 2), HUD_LOWER_Y + (HUD_OUTER_HEIGHT << 2), 
-                    G_TX_RENDERTILE, position_of_right_asset << 5, 0 << 5, 1 << 10, 1 << 10);
+                    HUD_UPPER_X, HUD_UPPER_Y,
+                    HUD_UPPER_X + (HUD_OUTER_WIDTH << 2), HUD_UPPER_Y + (HUD_OUTER_HEIGHT << 2),
+                    G_TX_RENDERTILE, position_of_left_asset << 5, 0 << 5, 1 << 10, 1 << 10);
             }
             
         }
@@ -97,30 +97,32 @@ void hudRender(struct RenderState* renderState, struct Player* player, int last_
         if (player->flags & PlayerHasSecondPortalGun){
             gDPSetPrimColor(renderState->dl++, 255, 255, 255, 128, 0, 255);
             if (looked_wall_portalable_0){
-                position_of_right_asset = (HUD_OUTER_WIDTH*3);
+                position_of_left_asset = (HUD_OUTER_WIDTH*2);
             }
             gSPTextureRectangle(renderState->dl++, 
-                HUD_LOWER_X, HUD_LOWER_Y,
-                HUD_LOWER_X + (HUD_OUTER_WIDTH << 2), HUD_LOWER_Y + (HUD_OUTER_HEIGHT << 2), 
-                G_TX_RENDERTILE, position_of_right_asset << 5, 0 << 5, 1 << 10, 1 << 10);
+                HUD_UPPER_X, HUD_UPPER_Y,
+                HUD_UPPER_X + (HUD_OUTER_WIDTH << 2), HUD_UPPER_Y + (HUD_OUTER_HEIGHT << 2), 
+                G_TX_RENDERTILE, position_of_left_asset << 5, 0 << 5, 1 << 10, 1 << 10);
         }
     }
     
 
     // both portal guns owned is only time when the last shot portal indicator appears
     if ((player->flags & PlayerHasSecondPortalGun) && (player->flags & PlayerHasFirstPortalGun) && last_portal_idx_shot != -1){
+        //orange indicator
         if (last_portal_idx_shot == 0){
             gDPSetPrimColor(renderState->dl++, 255, 255, 255, 128, 0, 255);
             gSPTextureRectangle(renderState->dl++, 
-                HUD_UPPER_X + 100, HUD_LOWER_Y,
-                HUD_UPPER_X + 100 + (HUD_OUTER_WIDTH << 2), HUD_LOWER_Y + (HUD_OUTER_HEIGHT << 2) , 
+                HUD_LOWER_X - 68, HUD_LOWER_Y,
+                HUD_LOWER_X - 68 + (HUD_OUTER_WIDTH << 2), HUD_LOWER_Y + (HUD_OUTER_HEIGHT << 2), 
                 G_TX_RENDERTILE, position_of_portal_indicator << 5, 0 << 5, 1 << 10, 1 << 10);
         }
+        //blue indicator
         else if (last_portal_idx_shot == 1){
             gDPSetPrimColor(renderState->dl++, 255, 255, 0, 128, 255, 255);
             gSPTextureRectangle(renderState->dl++, 
-                HUD_LOWER_X - 68, HUD_LOWER_Y,
-                HUD_LOWER_X - 68 + (HUD_OUTER_WIDTH << 2), HUD_LOWER_Y + (HUD_OUTER_HEIGHT << 2) , 
+                HUD_UPPER_X + 100, HUD_LOWER_Y,
+                HUD_UPPER_X + 100 + (HUD_OUTER_WIDTH << 2), HUD_LOWER_Y + (HUD_OUTER_HEIGHT << 2), 
                 G_TX_RENDERTILE, position_of_portal_indicator << 5, 0 << 5, 1 << 10, 1 << 10);
         }
     }


### PR DESCRIPTION
previously the HUD was conforming to the PC version of the game (orange on right, blue on left), however because we are targeting the console version for the remake the HUD colors have now been inverted (blue on right, orange on left) fully tested on emulator, new colored HUD images attached.

Fixes #112 

![Screenshot from 2023-07-28 09-56-17](https://github.com/lambertjamesd/portal64/assets/71656782/71817592-4ef9-4fa2-a26b-6efc7fb8b9bb)

![Screenshot from 2023-07-28 09-56-45](https://github.com/lambertjamesd/portal64/assets/71656782/c18e6270-07d5-48f2-ad47-9c27c69cfeed)

![Screenshot from 2023-07-28 09-57-10](https://github.com/lambertjamesd/portal64/assets/71656782/d01b1508-51f4-41bd-b4c3-e8c0e0cea020)

![Screenshot from 2023-07-28 09-57-27](https://github.com/lambertjamesd/portal64/assets/71656782/1bd60474-bea2-477f-b5ac-36d1d744e299)

![Screenshot from 2023-07-28 10-01-33](https://github.com/lambertjamesd/portal64/assets/71656782/b3fefc21-b8a8-41a3-a38f-7ed0610a4a58)

![Screenshot from 2023-07-28 10-01-45](https://github.com/lambertjamesd/portal64/assets/71656782/6d8a1008-05b2-4df6-8adc-76264f7682da)
