### PR TITLE
Correct Chamber Numbers

### DIFF
--- a/src/levels/levels.c
+++ b/src/levels/levels.c
@@ -207,3 +207,41 @@ struct Location* levelGetLocation(short index) {
 
     return &gCurrentLevel->locations[index];
 }
+
+int levelGetChamberNumber(int levelIndex, int roomIndex){
+    switch(levelIndex){
+        case 0:
+            if (roomIndex <= 2)
+                return 0;
+            else
+                return 1;
+        case 1:
+            if (roomIndex <= 2)
+                return 2;
+            else
+                return 3;
+        case 2:
+            if (roomIndex <= 2)
+                return 4;
+            else
+                return 5;
+        case 3:
+            if (roomIndex <= 2)
+                return 6;
+            else
+                return 7;
+        case 4:
+            return 8;
+        case 5:
+            return 9;
+        case 6:
+            return 10;
+        case 7:
+            if (roomIndex <= 2)
+                return 11;
+            else
+                return 12;
+        default:
+            return 0;
+    }
+}

--- a/src/levels/levels.h
+++ b/src/levels/levels.h
@@ -28,6 +28,8 @@ Gfx* levelMaterialRevert(int index);
 
 int levelQuadIndex(struct CollisionObject* pointer);
 
+int levelGetChamberNumber(int levelIndex, int roomIndex);
+
 struct Location* levelGetLocation(short index);
 
 #endif

--- a/src/menu/save_game_menu.c
+++ b/src/menu/save_game_menu.c
@@ -37,7 +37,7 @@ void saveGamePopulate(struct SaveGameMenu* saveGame, int includeNew) {
     if (includeNew && freeSlot != SAVEFILE_NO_SLOT) {
         savefileInfo[numberOfSaves].slotIndex = freeSlot;
         savefileInfo[numberOfSaves].savefileName = "NEW SAVE";
-        savefileInfo[numberOfSaves].testchamberIndex = gCurrentLevelIndex;
+        savefileInfo[numberOfSaves].testchamberIndex = levelGetChamberNumber(gCurrentLevelIndex, gScene.player.body.currentRoom);
         savefileInfo[numberOfSaves].screenshot = gScreenGrabBuffer;
 
         if (suggestedSlot == 0) {
@@ -60,7 +60,7 @@ enum MenuDirection saveGameUpdate(struct SaveGameMenu* saveGame) {
     if (controllerGetButtonDown(0, A_BUTTON) && saveGame->savefileList->numberOfSaves) {
         Checkpoint* save = stackMalloc(MAX_CHECKPOINT_SIZE);
         if (checkpointSaveInto(&gScene, save)) {
-            savefileSaveGame(save, gScreenGrabBuffer, gCurrentLevelIndex, gCurrentTestSubject, savefileGetSlot(saveGame->savefileList));
+            savefileSaveGame(save, gScreenGrabBuffer, levelGetChamberNumber(gCurrentLevelIndex, gScene.player.body.currentRoom), gCurrentTestSubject, savefileGetSlot(saveGame->savefileList));
             saveGamePopulate(saveGame, 0);
         }
         stackMallocFree(save);

--- a/src/savefile/checkpoint.c
+++ b/src/savefile/checkpoint.c
@@ -52,7 +52,7 @@ void checkpointSave(struct Scene* scene) {
     savefileGrabScreenshot();
     gHasCheckpoint = checkpointSaveInto(scene, gCheckpoint);
     // slot 0 is the autosave slot
-    savefileSaveGame(gCheckpoint, gScreenGrabBuffer, gCurrentLevelIndex, gCurrentTestSubject, 0);
+    savefileSaveGame(gCheckpoint, gScreenGrabBuffer, levelGetChamberNumber(gCurrentLevelIndex, gScene.player.body.currentRoom), gCurrentTestSubject, 0);
 }
 
 void checkpointLoadLast(struct Scene* scene) {


### PR DESCRIPTION
chamber numbers displayed in both the save and load screen menu's are now the correct number. I achieved this by making a function `levelGetChamberNumber` that creates a mapping from level/room numbers to chamber numbers

this mapping will need to be updated when new levels are added to the game, however its such low overhead that I think its okay. another option would be to store the chamber number when passing in or out of elevators and saving that number as the player progresses.

screenshots (of a couple chambers) attached.
all chambers verified to be working.

Fixes #197

![Screenshot from 2023-08-04 16-38-46](https://github.com/lambertjamesd/portal64/assets/71656782/2f0befc4-a1a5-4637-9fb9-f1928e06fd67)

![Screenshot from 2023-08-04 16-40-11](https://github.com/lambertjamesd/portal64/assets/71656782/0ac28314-d257-4797-be3a-743aa3772c25)

![Screenshot from 2023-08-04 16-41-05](https://github.com/lambertjamesd/portal64/assets/71656782/32c923f1-55da-41d1-bb51-26ca9576edad)

![Screenshot from 2023-08-04 16-42-14](https://github.com/lambertjamesd/portal64/assets/71656782/52f37d1c-2c25-4483-86a0-8488da47bfdd)

![Screenshot from 2023-08-04 16-43-22](https://github.com/lambertjamesd/portal64/assets/71656782/9138bd2b-265a-45fc-954d-c35f12bba9f4)



