### PR TITLE
Sound Crackling Noise Fix

### DIFF
--- a/src/audio/clips.c
+++ b/src/audio/clips.c
@@ -3,6 +3,19 @@
 
 #include "../../build/src/audio/clips.h"
 
+unsigned short soundsSkippable[10] = {
+    SOUNDS_PORTAL_ENTER1,
+    SOUNDS_PORTAL_ENTER2,
+    SOUNDS_PORTAL_EXIT1,
+    SOUNDS_PORTAL_EXIT2,
+    SOUNDS_PORTALGUN_SHOOT_RED1,
+    SOUNDS_PORTALGUN_SHOOT_BLUE1,
+    SOUNDS_CONCRETE1, //left foot
+    SOUNDS_CONCRETE2, //right foot
+    SOUNDS_CONCRETE3, //land
+    SOUNDS_CONCRETE4 //jump
+};
+
 unsigned short soundsPortalEnter[2] = {
     SOUNDS_PORTAL_ENTER1,
     SOUNDS_PORTAL_ENTER2,
@@ -60,3 +73,13 @@ unsigned short soundsBallLaunch = SOUNDS_ENERGY_SING_FLYBY1;
 unsigned short soundsBallBounce = SOUNDS_ENERGY_BOUNCE1;
 unsigned short soundsBallKill = SOUNDS_ENERGY_DISINTEGRATE4;
 unsigned short soundsBallExplode = SOUNDS_ENERGY_SING_EXPLOSION2;
+
+int clipsCheckSoundSkippable(unsigned short soundID){
+    int arrayLength = sizeof(soundsSkippable)/sizeof(soundsSkippable[0]);
+    for(int i=0; i<arrayLength; i++){
+        if (soundID == soundsSkippable[i]){
+            return 1;
+        }
+    }
+    return 0;
+}

--- a/src/audio/clips.h
+++ b/src/audio/clips.h
@@ -1,6 +1,8 @@
 #ifndef __AUDIO_CLIPS_H__
 #define __AUDIO_CLIPS_H__
 
+extern unsigned short soundsSkippable[10];
+
 extern unsigned short soundsPortalEnter[2];
 extern unsigned short soundsPortalExit[2];
 
@@ -31,5 +33,7 @@ extern unsigned short soundsBallLaunch;
 extern unsigned short soundsBallBounce;
 extern unsigned short soundsBallKill;
 extern unsigned short soundsBallExplode;
+
+int clipsCheckSoundSkippable(unsigned short soundID);
 
 #endif

--- a/src/audio/soundplayer.c
+++ b/src/audio/soundplayer.c
@@ -4,11 +4,13 @@
 #include "util/rom.h"
 #include "util/time.h"
 #include "math/mathf.h"
+#include "clips.h"
 
 struct SoundArray* gSoundClipArray;
 ALSndPlayer gSoundPlayer;
 
-#define MAX_ACTIVE_SOUNDS   16
+#define MAX_SKIPPABLE_SOUNDS    6
+#define MAX_ACTIVE_SOUNDS       12
 
 #define SOUND_FLAGS_3D          (1 << 0)
 #define SOUND_FLAGS_LOOPING     (1 << 1)
@@ -148,7 +150,10 @@ float soundPlayerEstimateLength(ALSound* sound, float speed) {
 }
 
 ALSndId soundPlayerPlay(int soundClipId, float volume, float pitch, struct Vector3* at, struct Vector3* velocity) {
-    if (gActiveSoundCount == MAX_ACTIVE_SOUNDS || soundClipId < 0 || soundClipId >= gSoundClipArray->soundCount) {
+    if (gActiveSoundCount >= MAX_ACTIVE_SOUNDS || soundClipId < 0 || soundClipId >= gSoundClipArray->soundCount) {
+        return SOUND_ID_NONE;
+    }
+    if (gActiveSoundCount >= MAX_SKIPPABLE_SOUNDS && clipsCheckSoundSkippable(soundClipId)) {
         return SOUND_ID_NONE;
     }
     

--- a/src/player/player.c
+++ b/src/player/player.c
@@ -464,13 +464,10 @@ void playerGivePortalGun(struct Player* player, int flags) {
 }
 
 void playerUpdateSpeedSound(struct Player* player) {
-    // float soundPlayerVolume;
-    // soundPlayerVolume = sqrtf(vector3MagSqrd(&player->body.velocity))*(1.0f / MAX_PORTAL_SPEED);
-    // soundPlayerVolume = clampf(soundPlayerVolume, 0.0, 1.0f);
-    // soundPlayerAdjustVolume(player->flyingSoundLoopId, soundPlayerVolume);
-
-    // char message[32];
-    // gdbSendMessage(GDBDataTypeText, message, sprintf(message, "%d", (int)(soundPlayerVolume * 100.0f)));
+    float soundPlayerVolume;
+    soundPlayerVolume = sqrtf(vector3MagSqrd(&player->body.velocity))*(0.6f / MAX_PORTAL_SPEED);
+    soundPlayerVolume = clampf(soundPlayerVolume, 0.0, 1.0f);
+    soundPlayerAdjustVolume(player->flyingSoundLoopId, soundPlayerVolume);
 }
 
 void playerKill(struct Player* player, int isUnderwater) {


### PR DESCRIPTION
this bug was caused by too many sounds playing at once. to alleviate this two things were implemented

- lowered the max number of active sounds from 16 to 12, this based on my testing eliminated all crackling sounds
- made an array of sound clips that are "skippable". also added a function to check if a given sound ID is skippable based on the list.

the idea here is there are some sounds (footsteps, portal shooting, portal entering, etc.) that are acceptable to be skipped. there are other sounds that are more important to not skip (glados speaking, menu sounds, buttons pressed, etc.). by marking some as skippable, those sounds will not be able to be played after the number of active sounds passes a `MAX_SKIPPABLE_SOUNDS` threshold. this makes the event of skipping an important sound like glados speaking MUCH less likely. as more sound effects are added to the game we will need to make sure to add them to that list if they are less important.

I also added back in the fast falling sound, and adjusted it a bit so it is the appropriate volume at the right times. 

Fixes #183