### PR TITLE
skelatool64: Avoid truncate warning in CFileDefinition

### DIFF
--- a/skelatool64/src/CFileDefinition.cpp
+++ b/skelatool64/src/CFileDefinition.cpp
@@ -322,8 +322,8 @@ std::string CFileDefinition::GetUniqueName(std::string requestedName) {
     int index = 1;
     
     while (mUsedNames.find(result) != mUsedNames.end()) {
-        char strBuffer[8];
-        snprintf(strBuffer, 8, "_%d", index);
+        char strBuffer[12];
+        snprintf(strBuffer, 12, "_%d", index);
         result = mPrefix + "_" + requestedName + strBuffer;
         makeCCompatible(result);
         ++index;


### PR DESCRIPTION
I don't know why only I seem to get this error while compiling skelatool64, but this should fix it hopefully without breaking anything? :)

The resulting ROM works fine.

> g++ -Wall -Werror -g -rdynamic -I./yaml-cpp/include  -c src/CFileDefinition.cpp -o build/src/CFileDefinition.o
> src/CFileDefinition.cpp: In member function ‘std::string CFileDefinition::GetUniqueName(std::string)’:
> src/CFileDefinition.cpp:326:34: error: ‘%d’ directive output may be truncated writing between 1 and 10 bytes into a region of size 7 [-Werror=format-truncation=]
>   326 |         snprintf(strBuffer, 8, "_%d", index);
>       |                                  ^~
> src/CFileDefinition.cpp:326:32: note: directive argument in the range [1, 2147483647]
>   326 |         snprintf(strBuffer, 8, "_%d", index);
>       |                                ^~~~~
> src/CFileDefinition.cpp:326:17: note: ‘snprintf’ output between 3 and 12 bytes into a destination of size 8
>   326 |         snprintf(strBuffer, 8, "_%d", index);
>       |         ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
> cc1plus: all warnings being treated as errors
> make: *** [makefile:28: build/src/CFileDefinition.o] Fehler 1

