### PR TITLE
mute DecorObjects in main_menu (Fixes #213)

### DIFF
--- a/src/decor/decor_object.c
+++ b/src/decor/decor_object.c
@@ -181,7 +181,7 @@ int decorObjectUpdate(struct DecorObject* decorObject) {
         return 0;
     }
 
-    if (decorObject->definition->soundClipId != -1 && decorObject->playingSound == SOUND_ID_NONE && decorObject->fizzleTime == 0.0f && !(decorObject->flags & DecorObjectFlagsMuted)) {
+    if (decorObject->definition->soundClipId != -1 && decorObject->playingSound == SOUND_ID_NONE && decorObject->fizzleTime == 0.0f && !(decorObject->definition->flags & DecorObjectFlagsMuted)) {
         decorObject->playingSound = soundPlayerPlay(decorObject->definition->soundClipId, 1.0f, 1.0f, &decorObject->rigidBody.transform.position, &decorObject->rigidBody.velocity);
     }
 

--- a/src/decor/decor_object.c
+++ b/src/decor/decor_object.c
@@ -181,7 +181,7 @@ int decorObjectUpdate(struct DecorObject* decorObject) {
         return 0;
     }
 
-    if (decorObject->definition->soundClipId != -1 && decorObject->playingSound == SOUND_ID_NONE && decorObject->fizzleTime == 0.0f) {
+    if (decorObject->definition->soundClipId != -1 && decorObject->playingSound == SOUND_ID_NONE && decorObject->fizzleTime == 0.0f && decorObject->flags & DecorObjectFlagsMuted) {
         decorObject->playingSound = soundPlayerPlay(decorObject->definition->soundClipId, 1.0f, 1.0f, &decorObject->rigidBody.transform.position, &decorObject->rigidBody.velocity);
     }
 

--- a/src/decor/decor_object.c
+++ b/src/decor/decor_object.c
@@ -181,7 +181,7 @@ int decorObjectUpdate(struct DecorObject* decorObject) {
         return 0;
     }
 
-    if (decorObject->definition->soundClipId != -1 && decorObject->playingSound == SOUND_ID_NONE && decorObject->fizzleTime == 0.0f && decorObject->flags & DecorObjectFlagsMuted) {
+    if (decorObject->definition->soundClipId != -1 && decorObject->playingSound == SOUND_ID_NONE && decorObject->fizzleTime == 0.0f && !(decorObject->flags & DecorObjectFlagsMuted)) {
         decorObject->playingSound = soundPlayerPlay(decorObject->definition->soundClipId, 1.0f, 1.0f, &decorObject->rigidBody.transform.position, &decorObject->rigidBody.velocity);
     }
 

--- a/src/decor/decor_object.h
+++ b/src/decor/decor_object.h
@@ -10,6 +10,7 @@ enum DecorObjectFlags {
     // important objects respawn at their original 
     // location if they escape the level
     DecorObjectFlagsImportant = (1 << 0),
+    DecorObjectFlagsMuted = (1 << 1),
 };
 
 struct DecorObjectDefinition {

--- a/src/decor/decor_object.h
+++ b/src/decor/decor_object.h
@@ -35,7 +35,6 @@ struct DecorObject {
     short dynamicId;
     ALSndId playingSound;
     float fizzleTime;
-    short flags;
 };
 
 struct DecorObject* decorObjectNew(struct DecorObjectDefinition* definition, struct Transform* at, int room);

--- a/src/decor/decor_object.h
+++ b/src/decor/decor_object.h
@@ -35,6 +35,7 @@ struct DecorObject {
     short dynamicId;
     ALSndId playingSound;
     float fizzleTime;
+    short flags;
 };
 
 struct DecorObject* decorObjectNew(struct DecorObjectDefinition* definition, struct Transform* at, int room);

--- a/src/menu/main_menu.c
+++ b/src/menu/main_menu.c
@@ -33,7 +33,7 @@ void mainMenuPlayAmbientSound() {
 }
 
 void mainMenuInit(struct GameMenu* gameMenu) {
-    sceneInitNoPauseMenu(&gScene);
+    sceneInitNoPauseMenu(&gScene, 1);
 
     gameMenuInit(gameMenu, gMainMenuOptions, sizeof(gMainMenuOptions) / sizeof(*gMainMenuOptions), 0);
 

--- a/src/scene/scene.c
+++ b/src/scene/scene.c
@@ -151,9 +151,9 @@ void sceneInitNoPauseMenu(struct Scene* scene, int mainMenuMode) {
             scene->decor[i] = decorObjectNew(decorObjectDefinitionForId(decorDef->decorId), &decorTransform, decorDef->roomIndex);
 
             if(mainMenuMode == 1) {
-                scene->decor[i]->definiton->flags |= DecorObjectFlagsMuted;
+                scene->decor[i]->definition->flags |= DecorObjectFlagsMuted;
             } else {
-                scene->decor[i]->definiton->flags &= ~(DecorObjectFlagsMuted);
+                scene->decor[i]->definition->flags &= ~(DecorObjectFlagsMuted);
             }
         }
     }

--- a/src/scene/scene.c
+++ b/src/scene/scene.c
@@ -151,8 +151,10 @@ void sceneInitNoPauseMenu(struct Scene* scene, int mainMenuMode) {
             scene->decor[i] = decorObjectNew(decorObjectDefinitionForId(decorDef->decorId), &decorTransform, decorDef->roomIndex);
 
             if(mainMenuMode == 1) {
-                scene->decor[i]->flags |= DecorObjectFlagsMuted;
-            }            
+                scene->decor[i]->definiton->flags |= DecorObjectFlagsMuted;
+            } else {
+                scene->decor[i]->definiton->flags &= ~(DecorObjectFlagsMuted);
+            }
         }
     }
 

--- a/src/scene/scene.c
+++ b/src/scene/scene.c
@@ -151,7 +151,7 @@ void sceneInitNoPauseMenu(struct Scene* scene, int mainMenuMode) {
             scene->decor[i] = decorObjectNew(decorObjectDefinitionForId(decorDef->decorId), &decorTransform, decorDef->roomIndex);
 
             if(mainMenuMode == 1) {
-                scene->decor[i]->flags = DecorObjectFlagsMuted;
+                scene->decor[i]->flags |= DecorObjectFlagsMuted;
             }            
         }
     }

--- a/src/scene/scene.c
+++ b/src/scene/scene.c
@@ -76,7 +76,7 @@ void sceneInitDynamicColliders(struct Scene* scene) {
 }
 
 void sceneInit(struct Scene* scene) {
-    sceneInitNoPauseMenu(scene);
+    sceneInitNoPauseMenu(scene, 0);
     
     gameMenuInit(&gGameMenu, gPauseMenuOptions, sizeof(gPauseMenuOptions) / sizeof(*gPauseMenuOptions), 1);
 
@@ -95,7 +95,7 @@ void sceneInit(struct Scene* scene) {
     gGameMenu.state = GameMenuStateResumeGame;
 }
 
-void sceneInitNoPauseMenu(struct Scene* scene) {
+void sceneInitNoPauseMenu(struct Scene* scene, int mainMenuMode) {
     signalsInit(1);
 
     cameraInit(&scene->camera, 70.0f, DEFAULT_NEAR_PLANE * SCENE_SCALE, DEFAULT_FAR_PLANE * SCENE_SCALE);
@@ -149,6 +149,10 @@ void sceneInitNoPauseMenu(struct Scene* scene) {
             decorTransform.rotation = decorDef->rotation;
             decorTransform.scale = gOneVec;
             scene->decor[i] = decorObjectNew(decorObjectDefinitionForId(decorDef->decorId), &decorTransform, decorDef->roomIndex);
+
+            if(mainMenuMode == 1) {
+                scene->decor[i]->flags = DecorObjectFlagsMuted;
+            }            
         }
     }
 

--- a/src/scene/scene.h
+++ b/src/scene/scene.h
@@ -90,7 +90,7 @@ extern struct Scene gScene;
 struct GraphicsTask;
 
 void sceneInit(struct Scene* scene);
-void sceneInitNoPauseMenu(struct Scene* scene);
+void sceneInitNoPauseMenu(struct Scene* scene, int mainMenuMode);
 void sceneRender(struct Scene* scene, struct RenderState* renderState, struct GraphicsTask* task);
 void sceneUpdate(struct Scene* scene);
 void sceneQueueCheckpoint(struct Scene* scene);


### PR DESCRIPTION
So this should fix DecorObjects like the radio playing when starting the main_menu. (#213 )
(though I can't confirm, since the radio was not audible for me on the main menu before).
The radio plays correctly ingame though, so I guess it should work! :)

Tested on Ares v133.