### PR TITLE
Can now navigate option menus with triggers

### DIFF
--- a/src/menu/options_menu.c
+++ b/src/menu/options_menu.c
@@ -56,19 +56,28 @@ void optionsMenuInit(struct OptionsMenu* options) {
 enum MenuDirection optionsMenuUpdate(struct OptionsMenu* options) {
     enum MenuDirection menuDirection = MenuDirectionStay;
 
-    switch (options->tabs.selectedTab) {
-        case OptionsMenuTabsControlMapping:
-            menuDirection = controlsMenuUpdate(&options->controlsMenu);
-            break;
-        case OptionsMenuTabsControlJoystick:
-            menuDirection = joystickOptionsUpdate(&options->joystickOptions);
-            break;
-        case OptionsMenuTabsAudio:
-            menuDirection = audioOptionsUpdate(&options->audioOptions);
-            break;
-        case OptionsMenuTabsGameplay:
-            menuDirection = gameplayOptionsUpdate(&options->gameplayOptions);
-            break;
+    if(controllerGetButtonDown(0, L_TRIG) || controllerGetButtonDown(0, Z_TRIG))
+        menuDirection = MenuDirectionLeft;
+
+    if(controllerGetButtonDown(0, R_TRIG))
+        menuDirection = MenuDirectionRight;
+
+    if(menuDirection == MenuDirectionStay)
+    {
+        switch (options->tabs.selectedTab) {
+            case OptionsMenuTabsControlMapping:
+                menuDirection = controlsMenuUpdate(&options->controlsMenu);
+                break;
+            case OptionsMenuTabsControlJoystick:
+                menuDirection = joystickOptionsUpdate(&options->joystickOptions);
+                break;
+            case OptionsMenuTabsAudio:
+                menuDirection = audioOptionsUpdate(&options->audioOptions);
+                break;
+            case OptionsMenuTabsGameplay:
+                menuDirection = gameplayOptionsUpdate(&options->gameplayOptions);
+                break;
+        }
     }
 
     if (menuDirection == MenuDirectionUp) {


### PR DESCRIPTION
Simple improvement to menu navigation. Will allow you to switch tabs with the triggers so you can change tabs even if you are on a slider.