### PR TITLE
Docker updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,10 +47,12 @@ RUN apt update -y && \
     mpg123 \
     wget
 
-RUN wget https://download.blender.org/release/Blender3.0/blender-3.0.0-linux-x64.tar.xz
+RUN mkdir /opt/blender
+RUN wget -P /opt/blender https://download.blender.org/release/Blender3.0/blender-3.0.0-linux-x64.tar.xz
 
-RUN tar -xf blender-3.0.0-linux-x64.tar.xz
+RUN tar -xf /opt/blender/blender-3.0.0-linux-x64.tar.xz -C /opt/blender
+RUN rm /opt/blender/blender-3.0.0-linux-x64.tar.xz
 
-ENV BLENDER_3_0 /usr/src/app/blender-3.0.0-linux-x64/blender
+ENV BLENDER_3_0 /opt/blender/blender-3.0.0-linux-x64/blender
 
 RUN pip install vpk

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -1,8 +1,11 @@
 all:
-	docker run  -v $$PWD:/usr/src/app -it portal64 make
+	docker run -v $$PWD:/usr/src/app -it portal64 make
 
 image:
 	docker build -t portal64 .
+
+convert_all_png:
+	docker run -v $$PWD:/usr/src/app -it portal64 make convert_all_png
 
 bash:
 	docker run  -v $$PWD:/usr/src/app -it portal64 bash


### PR DESCRIPTION
Blender was being extracted to the working directory, which was an issue. When specifying the working directory as a volume, you could no longer access the blender folder's contents. Blender is now extracted to /opt/blender.

I exposed `convert_all_png` make target to the docker makefile since it is currently required for first time setup.