### PR TITLE
Various Options Menu Improvements

### DIFF
--- a/src/menu/audio_options.c
+++ b/src/menu/audio_options.c
@@ -13,11 +13,11 @@ enum MenuDirection audioOptionsUpdate(struct AudioOptions* audioOptions) {
         return MenuDirectionUp;
     }
 
-    if (controllerDir & ControllerDirectionLeft) {
+    if ((controllerDir & ControllerDirectionLeft || controllerGetButtonDown(0, L_TRIG) || controllerGetButtonDown(0, Z_TRIG))) {
         return MenuDirectionLeft;
     }
 
-    if (controllerDir & ControllerDirectionRight) {
+    if ((controllerDir & ControllerDirectionRight || controllerGetButtonDown(0, R_TRIG))) {
         return MenuDirectionRight;
     }
 

--- a/src/menu/controls.c
+++ b/src/menu/controls.c
@@ -320,11 +320,11 @@ enum MenuDirection controlsMenuUpdate(struct ControlsMenu* controlsMenu) {
         return MenuDirectionUp;
     }
 
-    if (controllerDir & ControllerDirectionLeft) {
+    if ((controllerDir & ControllerDirectionLeft || controllerGetButtonDown(0, L_TRIG) || controllerGetButtonDown(0, Z_TRIG)) && !(controlsMenu->waitingForAction)) {
         return MenuDirectionLeft;
     }
 
-    if (controllerDir & ControllerDirectionRight) {
+    if ((controllerDir & ControllerDirectionRight || controllerGetButtonDown(0, R_TRIG) ) && !(controlsMenu->waitingForAction)) {
         return MenuDirectionRight;
     }
 

--- a/src/menu/gameplay_options.c
+++ b/src/menu/gameplay_options.c
@@ -78,11 +78,11 @@ enum MenuDirection gameplayOptionsUpdate(struct GameplayOptions* gameplayOptions
         break;
     }
 
-    if (controllerDir & ControllerDirectionLeft) {
+    if ((controllerDir & ControllerDirectionLeft || controllerGetButtonDown(0, L_TRIG) || controllerGetButtonDown(0, Z_TRIG))) {
         return MenuDirectionLeft;
     }
 
-    if (controllerDir & ControllerDirectionRight) {
+    if ((controllerDir & ControllerDirectionRight || controllerGetButtonDown(0, R_TRIG))) {
         return MenuDirectionRight;
     }
 

--- a/src/menu/joystick_options.h
+++ b/src/menu/joystick_options.h
@@ -6,6 +6,7 @@
 
 enum JoystickOption {
     JoystickOptionInvert,
+    JoystickOptionInvertYaw,
     JoystickOptionTankControls,
     JoystickOptionSensitivity,
     JoystickOptionAcceleration,
@@ -15,6 +16,7 @@ enum JoystickOption {
 
 struct JoystickOptions {
     struct MenuCheckbox invertControls;
+    struct MenuCheckbox invertControlsYaw;
     struct MenuCheckbox tankControls;
     struct MenuSlider lookSensitivity;
     struct MenuSlider lookAcceleration;

--- a/src/menu/options_menu.c
+++ b/src/menu/options_menu.c
@@ -56,12 +56,6 @@ void optionsMenuInit(struct OptionsMenu* options) {
 enum MenuDirection optionsMenuUpdate(struct OptionsMenu* options) {
     enum MenuDirection menuDirection = MenuDirectionStay;
 
-    if(controllerGetButtonDown(0, L_TRIG) || controllerGetButtonDown(0, Z_TRIG))
-        menuDirection = MenuDirectionLeft;
-
-    if(controllerGetButtonDown(0, R_TRIG))
-        menuDirection = MenuDirectionRight;
-
     if(menuDirection == MenuDirectionStay)
     {
         switch (options->tabs.selectedTab) {

--- a/src/player/player.c
+++ b/src/player/player.c
@@ -771,6 +771,9 @@ void playerUpdate(struct Player* player) {
     if (gSaveData.controls.flags & ControlSaveFlagsInvert) {
         targetPitch = -targetPitch;
     }
+    if (gSaveData.controls.flags & ControlSaveFlagsInvertYaw) {
+        targetYaw = -targetYaw;
+    }
 
     float rotateRateDelta = mathfLerp(MIN_ROTATE_RATE_DELTA, MAX_ROTATE_RATE_DELTA, (float)gSaveData.controls.acceleration / 0xFFFF);
 

--- a/src/savefile/savefile.h
+++ b/src/savefile/savefile.h
@@ -35,7 +35,8 @@ struct SaveHeader {
 
 enum ControlSaveFlags {
     ControlSaveFlagsInvert = (1 << 0),
-    ControlSaveTankControls = (1 << 1),
+    ControlSaveFlagsInvertYaw = (1 << 1),
+    ControlSaveTankControls = (1 << 2),
 
     ControlSaveMoveablePortals = (1 << 8),
     ControlSaveWideScreen = (1 << 9),


### PR DESCRIPTION
- fixed bug where you couldnt set L R or Z to an action because it would just change tabs
- instead of a global check for tab switch, each indiviudal menu tab determines if it should move to the next tab
- added an "invert camera yaw" option

![image](https://github.com/lambertjamesd/portal64/assets/71656782/0d512e92-507c-433c-958b-f50ffbedaf53)


Fixes #218