### PR TITLE
Various Tweaks to Portal Gun Mechanics

### DIFF
--- a/src/audio/clips.c
+++ b/src/audio/clips.c
@@ -3,13 +3,11 @@
 
 #include "../../build/src/audio/clips.h"
 
-unsigned short soundsSkippable[10] = {
+unsigned short soundsSkippable[8] = {
     SOUNDS_PORTAL_ENTER1,
     SOUNDS_PORTAL_ENTER2,
     SOUNDS_PORTAL_EXIT1,
     SOUNDS_PORTAL_EXIT2,
-    SOUNDS_PORTALGUN_SHOOT_RED1,
-    SOUNDS_PORTALGUN_SHOOT_BLUE1,
     SOUNDS_CONCRETE1, //left foot
     SOUNDS_CONCRETE2, //right foot
     SOUNDS_CONCRETE3, //land

--- a/src/audio/clips.h
+++ b/src/audio/clips.h
@@ -1,7 +1,7 @@
 #ifndef __AUDIO_CLIPS_H__
 #define __AUDIO_CLIPS_H__
 
-extern unsigned short soundsSkippable[10];
+extern unsigned short soundsSkippable[8];
 
 extern unsigned short soundsPortalEnter[2];
 extern unsigned short soundsPortalExit[2];

--- a/src/controls/controller_actions.c
+++ b/src/controls/controller_actions.c
@@ -136,7 +136,9 @@ void controllerActionRead() {
                 if (sourceIndex == ControllerActionSourceCUpButton || sourceIndex == ControllerActionSourceDUpButton) {
                     sourceIndex += 3;
                 }
-            } else if (controllerGetButtonDown(controllerIndex, gActionSourceButtonMask[sourceIndex])) {
+            }else if (IS_HOLDABLE_ACTION(action) && controllerGetButton(controllerIndex, gActionSourceButtonMask[sourceIndex])){
+                controllerActionApply(action);
+            }else if (controllerGetButtonDown(controllerIndex, gActionSourceButtonMask[sourceIndex])) {
                 controllerActionApply(action);
             }
         }

--- a/src/controls/controller_actions.h
+++ b/src/controls/controller_actions.h
@@ -46,6 +46,7 @@ enum ControllerAction {
 };
 
 #define IS_DIRECTION_ACTION(action)     ((action) >= ControllerActionMove && (action) <= ControllerActionRotate)
+#define IS_HOLDABLE_ACTION(action)     ((action) >= ControllerActionOpenPortal0 && (action) <= ControllerActionOpenPortal1)
 #define IS_VALID_SOURCE(source) ((source) >= 0 && (source) < ControllerActionSourceCount)
 
 #define MAX_DEADZONE    0.25f

--- a/src/scene/portal_gun.c
+++ b/src/scene/portal_gun.c
@@ -12,7 +12,7 @@
 #include "../../build/assets/models/portal_gun/v_portalgun.h"
 #include "../../build/assets/materials/static.h"
 
-#define PORTAL_GUN_RECOIL_TIME (0.18f)
+#define PORTAL_GUN_RECOIL_TIME (0.22f)
 
 #define PORTAL_GUN_NEAR_PLANE   0.05f
 
@@ -52,6 +52,7 @@ void portalGunInit(struct PortalGun* portalGun, struct Transform* at){
     portalGun->rigidBody.angularVelocity = gZeroVec;
     portalGun->portalGunVisible = 0;
     portalGun->shootAnimationTimer = 0.0;
+    portalGun->shootTotalAnimationTimer = 0.0;
 
     portalGunCalcTargetPosition(portalGun, at, &portalGun->rigidBody.transform.position, 0);
 
@@ -180,6 +181,7 @@ void portalGunUpdate(struct PortalGun* portalGun, struct Player* player) {
 
     if (player->flags & PlayerJustShotPortalGun && portalGun->shootAnimationTimer <= 0.0f) {
         portalGun->shootAnimationTimer = PORTAL_GUN_RECOIL_TIME;
+        portalGun->shootTotalAnimationTimer = PORTAL_GUN_RECOIL_TIME * 2.0f; 
     }
 
     if (portalGun->shootAnimationTimer >= 0.0f) {
@@ -187,6 +189,12 @@ void portalGunUpdate(struct PortalGun* portalGun, struct Player* player) {
         if (portalGun->shootAnimationTimer <= 0.0f){
             portalGun->shootAnimationTimer = 0.0f;
             player->flags &= ~PlayerJustShotPortalGun;
+        }
+    }
+    if (portalGun->shootTotalAnimationTimer >= 0.0f) {
+        portalGun->shootTotalAnimationTimer -= FIXED_DELTA_TIME;
+        if (portalGun->shootTotalAnimationTimer <= 0.0f){
+            portalGun->shootTotalAnimationTimer = 0.0f;
         }
     }
 
@@ -258,4 +266,10 @@ void portalGunFire(struct PortalGun* portalGun, int portalIndex, struct Ray* ray
     vector3Add(&projectile->effectOffset, &ray->origin, &fireFrom);
 
     portalTrailPlay(&projectile->trail, &fireFrom, &hit.at);
+}
+int portalGunIsFiring(struct PortalGun* portalGun){
+    if (portalGun->shootTotalAnimationTimer > 0.0f){
+        return 1;
+    }
+    return 0;
 }

--- a/src/scene/portal_gun.h
+++ b/src/scene/portal_gun.h
@@ -31,6 +31,7 @@ struct PortalGun {
     struct RigidBody rigidBody;
     int portalGunVisible;
     float shootAnimationTimer;
+    float shootTotalAnimationTimer;
 
     struct PortalGunProjectile projectiles[2];
 };
@@ -41,5 +42,6 @@ void portalGunUpdate(struct PortalGun* portalGun, struct Player* player);
 void portalGunRenderReal(struct PortalGun* portalGun, struct RenderState* renderState, struct Camera* fromCamera);
 
 void portalGunFire(struct PortalGun* portalGun, int portalIndex, struct Ray* ray, struct Vector3* playerUp, int roomIndex);
+int portalGunIsFiring(struct PortalGun* portalGun);
 
 #endif

--- a/src/scene/scene.c
+++ b/src/scene/scene.c
@@ -347,14 +347,14 @@ void sceneCheckPortals(struct Scene* scene) {
         sceneFirePortal(scene, &scene->savedPortal.ray, &scene->savedPortal.transformUp, scene->savedPortal.portalIndex, scene->savedPortal.roomIndex, 0, 0);
     }
 
-    if (fireOrange && hasOrange && !playerIsGrabbing(&scene->player)) {
+    if (fireOrange && !fireBlue && hasOrange && !playerIsGrabbing(&scene->player) && !portalGunIsFiring(&scene->portalGun)) {
         portalGunFire(&scene->portalGun, 0, &raycastRay, &playerUp, scene->player.body.currentRoom);
         scene->player.flags |= PlayerJustShotPortalGun;
         hudPortalFired(&scene->hud, 0);
         soundPlayerPlay(soundsPortalgunShoot[0], 1.0f, 1.0f, NULL, NULL);
     }
 
-    if ((fireBlue || (!hasOrange && fireOrange)) && hasBlue && !playerIsGrabbing(&scene->player)) {
+    if ((fireBlue || (!hasOrange && fireOrange)) && !fireOrange && hasBlue && !playerIsGrabbing(&scene->player) &&!portalGunIsFiring(&scene->portalGun)) {
         portalGunFire(&scene->portalGun, 1, &raycastRay, &playerUp, scene->player.body.currentRoom);
         scene->player.flags |= PlayerJustShotPortalGun;
         hudPortalFired(&scene->hud, 1);


### PR DESCRIPTION
- tweaked portal gun to have a max fire rate, that is tied to its animation speed (used video of portal1 for reference)
- allowed `ControllerActionOpenPortal0` and `ControllerActionOpenPortal1` actions to be "Holdable" meaning that you can hold down the button and continuously do that action
- made sure two portals cant be shot at once, prohibiting both buttons being held at once.
- made portal shoot sound unskippable. it feels really bad to pull the trigger and not hear the sound because it was culled.

video attached:

https://github.com/lambertjamesd/portal64/assets/71656782/9ef83f92-6126-4020-ab58-31d3ddf49717

