### PR TITLE
Game Options Menu Tweaks

### DIFF
--- a/src/menu/controls.c
+++ b/src/menu/controls.c
@@ -128,7 +128,7 @@ struct ControlActionDataRow gControllerDataRows[] = {
     {"Pause", ControllerActionPause, "Misc"},
 
     {"Look forward", ControllerActionLookForward, "Misc Movement"},
-    {"Look backward", ControllerActionLookForward, NULL},
+    {"Look backward", ControllerActionLookBackward, NULL},
 };
 
 int controlsMeasureIcons(enum ControllerAction action) {

--- a/src/menu/gameplay_options.c
+++ b/src/menu/gameplay_options.c
@@ -23,8 +23,47 @@ void gameplayOptionsInit(struct GameplayOptions* gameplayOptions) {
     gameplayOptions->movingPortals = menuBuildCheckbox(&gDejaVuSansFont, "Movable Portals", GAMEPLAY_X + 8, GAMEPLAY_Y + 8);
     gameplayOptions->wideScreen = menuBuildCheckbox(&gDejaVuSansFont, "Wide Screen", GAMEPLAY_X + 8, GAMEPLAY_Y + 28);
 
+    gameplayOptions->portalRenderDepthText = menuBuildText(&gDejaVuSansFont, "Portal Render Depth", GAMEPLAY_X + 8, GAMEPLAY_Y + 48);
+    gameplayOptions->portalRenderDepth = menuBuildSlider(GAMEPLAY_X + 126, GAMEPLAY_Y + 48, 126, SCROLL_TICKS);
+
     gameplayOptions->movingPortals.checked = (gSaveData.controls.flags & ControlSaveMoveablePortals) != 0;
     gameplayOptions->wideScreen.checked = (gSaveData.controls.flags & ControlSaveWideScreen) != 0;
+    gameplayOptions->portalRenderDepth.value = (float)gSaveData.controls.portalRenderDepth / 0xFFFF;
+}
+
+#define FULL_SCROLL_TIME    2.0f
+#define SCROLL_MULTIPLIER   (int)(0xFFFF * FIXED_DELTA_TIME / (80 * FULL_SCROLL_TIME))
+#define SCROLL_CHUNK_SIZE   (0x10000 / SCROLL_INTERVALS)
+
+void gameplayOptionsHandleSlider(unsigned short* settingValue, float* sliderValue) {
+    OSContPad* pad = controllersGetControllerData(0);
+
+    int newValue = (int)*settingValue + pad->stick_x * SCROLL_MULTIPLIER;
+
+    if (controllerGetButtonDown(0, A_BUTTON | R_JPAD)) {
+        if (newValue >= 0xFFFF && controllerGetButtonDown(0, A_BUTTON)) {
+            newValue = 0;
+        } else {
+            newValue = newValue + SCROLL_CHUNK_SIZE;
+            newValue = newValue - (newValue % SCROLL_CHUNK_SIZE);
+        }
+    }
+
+    if (controllerGetButtonDown(0, L_JPAD)) {
+        newValue = newValue - 1;
+        newValue = newValue - (newValue % SCROLL_CHUNK_SIZE);
+    }
+
+    if (newValue < 0) {
+        newValue = 0;
+    }
+
+    if (newValue > 0xFFFF) {
+        newValue = 0xFFFF;
+    }
+
+    *settingValue = newValue;
+    *sliderValue = (float)newValue / 0xFFFF;
 }
 
 enum MenuDirection gameplayOptionsUpdate(struct GameplayOptions* gameplayOptions) {
@@ -75,15 +114,27 @@ enum MenuDirection gameplayOptionsUpdate(struct GameplayOptions* gameplayOptions
                     gSaveData.controls.flags &= ~ControlSaveWideScreen;
                 }
             }
+        case GameplayOptionPortalRenderDepth:
+            gameplayOptionsHandleSlider(&gSaveData.controls.portalRenderDepth, &gameplayOptions->portalRenderDepth.value);
+            break;
         break;
     }
 
-    if ((controllerDir & ControllerDirectionLeft || controllerGetButtonDown(0, L_TRIG) || controllerGetButtonDown(0, Z_TRIG))) {
-        return MenuDirectionLeft;
+    if (gameplayOptions->selectedItem == GameplayOptionPortalRenderDepth){
+        if ((controllerGetButtonDown(0, L_TRIG) || controllerGetButtonDown(0, Z_TRIG))) {
+            return MenuDirectionLeft;
+        }
+        if ((controllerGetButtonDown(0, R_TRIG))) {
+            return MenuDirectionRight;
+        }
     }
-
-    if ((controllerDir & ControllerDirectionRight || controllerGetButtonDown(0, R_TRIG))) {
-        return MenuDirectionRight;
+    else{
+        if (controllerDir & ControllerDirectionLeft || controllerGetButtonDown(0, L_TRIG) || controllerGetButtonDown(0, Z_TRIG)) {
+            return MenuDirectionLeft;
+        }
+        if (controllerDir & ControllerDirectionRight || controllerGetButtonDown(0, R_TRIG)) {
+            return MenuDirectionRight;
+        }
     }
 
     return MenuDirectionStay;
@@ -98,6 +149,9 @@ void gameplayOptionsRender(struct GameplayOptions* gameplayOptions, struct Rende
     gSPDisplayList(renderState->dl++, gameplayOptions->wideScreen.outline);
     renderState->dl = menuCheckboxRender(&gameplayOptions->wideScreen, renderState->dl);
 
+    gSPDisplayList(renderState->dl++, gameplayOptions->portalRenderDepth.back);
+    renderState->dl = menuSliderRender(&gameplayOptions->portalRenderDepth, renderState->dl);
+
     gSPDisplayList(renderState->dl++, ui_material_revert_list[SOLID_ENV_INDEX]);
 
     gSPDisplayList(renderState->dl++, ui_material_list[DEJAVU_SANS_INDEX]);
@@ -108,6 +162,10 @@ void gameplayOptionsRender(struct GameplayOptions* gameplayOptions, struct Rende
 
     menuSetRenderColor(renderState, gameplayOptions->selectedItem == GameplayOptionWideScreen, &gSelectionGray, &gColorWhite);
     gSPDisplayList(renderState->dl++, gameplayOptions->wideScreen.text);
+
+    gDPPipeSync(renderState->dl++);
+    menuSetRenderColor(renderState, gameplayOptions->selectedItem == GameplayOptionPortalRenderDepth, &gSelectionGray, &gColorWhite);
+    gSPDisplayList(renderState->dl++, gameplayOptions->portalRenderDepthText);
 
     gSPDisplayList(renderState->dl++, ui_material_revert_list[DEJAVU_SANS_INDEX]);
 }

--- a/src/menu/gameplay_options.h
+++ b/src/menu/gameplay_options.h
@@ -7,6 +7,7 @@
 enum GameplayOption {
     GameplayOptionMovingPortals,
     GameplayOptionWideScreen,
+    GameplayOptionPortalRenderDepth,
     
     GameplayOptionCount,
 };
@@ -14,8 +15,8 @@ enum GameplayOption {
 struct GameplayOptions {
     struct MenuCheckbox movingPortals;
     struct MenuCheckbox wideScreen;
-    Gfx* lookSensitivityText;
-    Gfx* lookAccelerationText;
+    struct MenuSlider portalRenderDepth;
+    Gfx* portalRenderDepthText;
     short selectedItem;
 };
 

--- a/src/menu/gameplay_options.h
+++ b/src/menu/gameplay_options.h
@@ -18,6 +18,7 @@ struct GameplayOptions {
     struct MenuSlider portalRenderDepth;
     Gfx* portalRenderDepthText;
     short selectedItem;
+    unsigned short render_depth;
 };
 
 void gameplayOptionsInit(struct GameplayOptions* gameplayOptions);

--- a/src/savefile/savefile.c
+++ b/src/savefile/savefile.c
@@ -91,9 +91,10 @@ void savefileNew() {
 
     controllerSetDefaultSource();
     gSaveData.controls.flags = 0;
-    gSaveData.controls.sensitivity = 0x7FFF;
-    gSaveData.controls.acceleration = 0x7FFF;
+    gSaveData.controls.sensitivity = 0x4000;
+    gSaveData.controls.acceleration = 0x4000;
     gSaveData.controls.deadzone = 0x4000;
+    gSaveData.controls.portalRenderDepth = 0x4000;
 
     gSaveData.audio.soundVolume = 0xFF;
     gSaveData.audio.musicVolume = 0xFF;

--- a/src/savefile/savefile.c
+++ b/src/savefile/savefile.c
@@ -94,7 +94,7 @@ void savefileNew() {
     gSaveData.controls.sensitivity = 0x4000;
     gSaveData.controls.acceleration = 0x4000;
     gSaveData.controls.deadzone = 0x4000;
-    gSaveData.controls.portalRenderDepth = 0x4000;
+    gSaveData.controls.portalRenderDepth = 2;
 
     gSaveData.audio.soundVolume = 0xFF;
     gSaveData.audio.musicVolume = 0xFF;

--- a/src/savefile/savefile.h
+++ b/src/savefile/savefile.h
@@ -47,6 +47,7 @@ struct ControlSaveState {
     unsigned short flags;
     unsigned short sensitivity;
     unsigned short acceleration;
+    unsigned short portalRenderDepth;
     unsigned short deadzone;
 };
 

--- a/src/savefile/savefile.h
+++ b/src/savefile/savefile.h
@@ -47,7 +47,7 @@ struct ControlSaveState {
     unsigned short flags;
     unsigned short sensitivity;
     unsigned short acceleration;
-    unsigned short portalRenderDepth;
+    int portalRenderDepth;
     unsigned short deadzone;
 };
 

--- a/src/scene/dynamic_render_list.c
+++ b/src/scene/dynamic_render_list.c
@@ -184,7 +184,7 @@ void dynamicRenderListPopulate(struct DynamicRenderDataList* list, struct Render
                 continue;
             }
 
-            if (stages[stageIndex].currentDepth == ((int)(gSaveData.controls.portalRenderDepth * (1.0f / 0xFFFF) * PORTAL_RENDER_DEPTH_MAX)) && (object->flags & DYNAMIC_SCENE_OBJECT_SKIP_ROOT)) {
+            if (stages[stageIndex].currentDepth == gSaveData.controls.portalRenderDepth && (object->flags & DYNAMIC_SCENE_OBJECT_SKIP_ROOT)) {
                 continue;
             }
 

--- a/src/scene/dynamic_render_list.c
+++ b/src/scene/dynamic_render_list.c
@@ -3,6 +3,7 @@
 #include "dynamic_scene.h"
 #include "../util/memory.h"
 #include "../physics/collision_scene.h"
+#include "../savefile/savefile.h"
 
 extern struct DynamicScene gDynamicScene;
 
@@ -183,7 +184,7 @@ void dynamicRenderListPopulate(struct DynamicRenderDataList* list, struct Render
                 continue;
             }
 
-            if (stages[stageIndex].currentDepth == STARTING_RENDER_DEPTH && (object->flags & DYNAMIC_SCENE_OBJECT_SKIP_ROOT)) {
+            if (stages[stageIndex].currentDepth == ((int)(gSaveData.controls.portalRenderDepth * (1.0f / 0xFFFF) * PORTAL_RENDER_DEPTH_MAX)) && (object->flags & DYNAMIC_SCENE_OBJECT_SKIP_ROOT)) {
                 continue;
             }
 

--- a/src/scene/portal.h
+++ b/src/scene/portal.h
@@ -11,7 +11,7 @@
 #include "./portal_surface.h"
 #include "../physics/collision_object.h"
 
-#define STARTING_RENDER_DEPTH       2
+#define PORTAL_RENDER_DEPTH_MAX  8
 #define PORTAL_LOOP_SIZE    8
 
 enum PortalFlags {

--- a/src/scene/render_plan.c
+++ b/src/scene/render_plan.c
@@ -32,7 +32,7 @@ void renderPropsInit(struct RenderProps* props, struct Camera* camera, float asp
     cameraSetupMatrices(camera, renderState, aspectRatio, &fullscreenViewport, 1, &props->cameraMatrixInfo);
 
     props->viewport = &fullscreenViewport;
-    props->currentDepth = STARTING_RENDER_DEPTH;
+    props->currentDepth = ((int)(gSaveData.controls.portalRenderDepth * (1.0f / 0xFFFF) * PORTAL_RENDER_DEPTH_MAX));
     props->exitPortalIndex = NO_PORTAL;
     props->fromRoom = roomIndex;
     props->parentStageIndex = -1;
@@ -70,12 +70,12 @@ void renderPropscheckViewportSize(int* min, int* max, int screenSize) {
 }
 
 int renderPropsZDistance(int currentDepth) {
-    if (currentDepth >= STARTING_RENDER_DEPTH) {
+    if (currentDepth >= ((int)(gSaveData.controls.portalRenderDepth * (1.0f / 0xFFFF) * PORTAL_RENDER_DEPTH_MAX))) {
         return 0;
     } else if (currentDepth < 0) {
         return G_MAXZ;
     } else {
-        return G_MAXZ - (G_MAXZ >> (STARTING_RENDER_DEPTH - currentDepth));
+        return G_MAXZ - (G_MAXZ >> (((int)(gSaveData.controls.portalRenderDepth * (1.0f / 0xFFFF) * PORTAL_RENDER_DEPTH_MAX)) - currentDepth));
     }
 }
 
@@ -337,7 +337,7 @@ int renderShouldRenderOtherPortal(struct Scene* scene, int visiblePortal, struct
         return 0;
     }
 
-    if ((scene->player.body.flags & (RigidBodyIsTouchingPortalA << visiblePortal)) != 0 && properties->currentDepth == STARTING_RENDER_DEPTH) {
+    if ((scene->player.body.flags & (RigidBodyIsTouchingPortalA << visiblePortal)) != 0 && properties->currentDepth == ((int)(gSaveData.controls.portalRenderDepth * (1.0f / 0xFFFF) * PORTAL_RENDER_DEPTH_MAX))) {
         return 1;
     }
 
@@ -415,9 +415,9 @@ void renderPlanFinishView(struct RenderPlan* renderPlan, struct Scene* scene, st
 }
 
 void renderPlanAdjustViewportDepth(struct RenderPlan* renderPlan) {
-    float depthWeight[STARTING_RENDER_DEPTH + 1];
+    float depthWeight[((int)(gSaveData.controls.portalRenderDepth * (1.0f / 0xFFFF) * PORTAL_RENDER_DEPTH_MAX)) + 1];
 
-    for (int i = 0; i <= STARTING_RENDER_DEPTH; ++i) {
+    for (int i = 0; i <= ((int)(gSaveData.controls.portalRenderDepth * (1.0f / 0xFFFF) * PORTAL_RENDER_DEPTH_MAX)); ++i) {
         depthWeight[i] = 0.0f;
     }
 
@@ -431,21 +431,21 @@ void renderPlanAdjustViewportDepth(struct RenderPlan* renderPlan) {
 
     float totalWeight = 0.0f;
 
-    for (int i = 0; i <= STARTING_RENDER_DEPTH; ++i) {
+    for (int i = 0; i <= ((int)(gSaveData.controls.portalRenderDepth * (1.0f / 0xFFFF) * PORTAL_RENDER_DEPTH_MAX)); ++i) {
         totalWeight += depthWeight[i];
     }
 
     // give the main view a larger slice of the depth buffer
-    totalWeight += depthWeight[STARTING_RENDER_DEPTH];
-    depthWeight[STARTING_RENDER_DEPTH] *= 2.0f;
+    totalWeight += depthWeight[((int)(gSaveData.controls.portalRenderDepth * (1.0f / 0xFFFF) * PORTAL_RENDER_DEPTH_MAX))];
+    depthWeight[((int)(gSaveData.controls.portalRenderDepth * (1.0f / 0xFFFF) * PORTAL_RENDER_DEPTH_MAX))] *= 2.0f;
 
     float scale = (float)G_MAXZ / totalWeight;
 
-    short zBufferBoundary[STARTING_RENDER_DEPTH + 2];
+    short zBufferBoundary[((int)(gSaveData.controls.portalRenderDepth * (1.0f / 0xFFFF) * PORTAL_RENDER_DEPTH_MAX)) + 2];
 
-    zBufferBoundary[STARTING_RENDER_DEPTH + 1] = 0;
+    zBufferBoundary[((int)(gSaveData.controls.portalRenderDepth * (1.0f / 0xFFFF) * PORTAL_RENDER_DEPTH_MAX)) + 1] = 0;
 
-    for (int i = STARTING_RENDER_DEPTH; i >= 0; --i) {
+    for (int i = ((int)(gSaveData.controls.portalRenderDepth * (1.0f / 0xFFFF) * PORTAL_RENDER_DEPTH_MAX)); i >= 0; --i) {
         zBufferBoundary[i] = (short)(scale * depthWeight[i]) + zBufferBoundary[i + 1];
 
         zBufferBoundary[i] = MIN(zBufferBoundary[i], G_MAXZ);

--- a/src/scene/scene.c
+++ b/src/scene/scene.c
@@ -522,8 +522,7 @@ void sceneUpdate(struct Scene* scene) {
     scene->lastFrameTime = frameStart - scene->lastFrameStart;
 
     if (gGameMenu.state != GameMenuStateResumeGame) {
-        if (controllerActionGet(ControllerActionPause) || 
-            (gGameMenu.state == GameMenuStateLanding && controllerGetButtonDown(0, B_BUTTON))) {
+        if (gGameMenu.state == GameMenuStateLanding && controllerGetButtonDown(0, B_BUTTON)) {
             gGameMenu.state = GameMenuStateResumeGame;
             savefileSave();
         }


### PR DESCRIPTION
This PR implements the following quality of life/bug fixes, as well as a new feature:
- fixed a minor bug where you couldn't apply a single button to look forward/look back
- start no longer exits the menu. this is because if the player set a or b buttons as the pause action, they could no longer use the menu's anymore, because it would exit them from the menu.
- adjusted the sensitivity/acceleration sliders down slightly
- added a portal render depth slider in the `GameplayOptions` menu. this allows the player to adjust the portal render depth in real time. this was in the original game in the menu so I replicated here.

attached video shows new menu additions.

https://github.com/lambertjamesd/portal64/assets/71656782/b7e592db-7bb2-4e0f-be3d-880c1bbc1c24

