### PR TITLE
Fixes Portal Height

### DIFF
--- a/src/physics/collision_scene.c
+++ b/src/physics/collision_scene.c
@@ -186,8 +186,8 @@ int collisionSceneIsTouchingSinglePortal(struct Vector3* contactPoint, struct Ve
         return 0;
     }
 
-    localPoint.x *= (2.0f / PORTAL_COVER_WIDTH);
-    localPoint.y *= (2.0f / PORTAL_COVER_HEIGHT);
+    localPoint.x *= (1.0f / PORTAL_COVER_WIDTH_RADIUS);
+    localPoint.y *= (1.0f / PORTAL_COVER_HEIGHT_RADIUS);
     localPoint.z = 0.0f;
 
     if (vector3MagSqrd(&localPoint) >= 1.0f) {

--- a/src/physics/collision_scene.h
+++ b/src/physics/collision_scene.h
@@ -8,8 +8,8 @@
 #include "defs.h"
 #include "point_constraint.h"
 
-#define PORTAL_COVER_HEIGHT 1.6
-#define PORTAL_COVER_WIDTH  0.84085f
+#define PORTAL_COVER_HEIGHT_RADIUS 0.708084f
+#define PORTAL_COVER_WIDTH_RADIUS  0.420425f
 
 #define PORTAL_THICKNESS        0.11f
 

--- a/src/physics/collision_scene.h
+++ b/src/physics/collision_scene.h
@@ -8,7 +8,7 @@
 #include "defs.h"
 #include "point_constraint.h"
 
-#define PORTAL_COVER_HEIGHT 0.708084f
+#define PORTAL_COVER_HEIGHT 1.6
 #define PORTAL_COVER_WIDTH  0.84085f
 
 #define PORTAL_THICKNESS        0.11f

--- a/src/scene/portal.c
+++ b/src/scene/portal.c
@@ -31,13 +31,13 @@ struct ColliderTypeData gPortalColliderType = {
 
 struct Vector3 gPortalOutline[PORTAL_LOOP_SIZE] = {
     {0.0f, 1.0f * SCENE_SCALE * PORTAL_COVER_HEIGHT_RADIUS, 0},
-    {SCENE_SCALE * PORTAL_COVER_WIDTH_RADIUS, SCENE_SCALE * PORTAL_COVER_HEIGHT_RADIUS, 0},
-    {0.5f * SCENE_SCALE * PORTAL_COVER_WIDTH_RADIUS, 0.0f, 0},
-    {SCENE_SCALE * PORTAL_COVER_WIDTH_RADIUS, -1.0f * SCENE_SCALE * PORTAL_COVER_HEIGHT_RADIUS, 0},
+    {0.707107f * SCENE_SCALE * PORTAL_COVER_WIDTH_RADIUS, SCENE_SCALE * PORTAL_COVER_HEIGHT_RADIUS, 0},
+    {1.0f * SCENE_SCALE * PORTAL_COVER_WIDTH_RADIUS, 0.0f, 0},
+    {0.707107f * SCENE_SCALE * PORTAL_COVER_WIDTH_RADIUS, -1.0f * SCENE_SCALE * PORTAL_COVER_HEIGHT_RADIUS, 0},
     {0.0f, -1.0f * SCENE_SCALE * PORTAL_COVER_HEIGHT_RADIUS, 0},
-    {-1.0f * SCENE_SCALE * PORTAL_COVER_WIDTH_RADIUS, -1.0f * SCENE_SCALE * PORTAL_COVER_HEIGHT_RADIUS, 0},
-    {-0.5f * SCENE_SCALE * PORTAL_COVER_WIDTH_RADIUS, 0.0f, 0},
-    {-1.0f * SCENE_SCALE * PORTAL_COVER_WIDTH_RADIUS, SCENE_SCALE * PORTAL_COVER_HEIGHT_RADIUS, 0},
+    {-0.707107f * SCENE_SCALE * PORTAL_COVER_WIDTH_RADIUS, -1.0f * SCENE_SCALE * PORTAL_COVER_HEIGHT_RADIUS, 0},
+    {-1.0f * SCENE_SCALE * PORTAL_COVER_WIDTH_RADIUS, 0.0f, 0},
+    {-0.707107f * SCENE_SCALE * PORTAL_COVER_WIDTH_RADIUS, SCENE_SCALE * PORTAL_COVER_HEIGHT_RADIUS, 0},
 };
 
 #define PORTAL_CLIPPING_PLANE_BIAS  (SCENE_SCALE * 0.25f)
@@ -86,12 +86,12 @@ void portalCalculateBB(struct Transform* portalTransform, struct Box3D* bb) {
     bb->min = bb->max = portalTransform->position;
 
     struct Vector3 nextDir;
-    vector3Scale(&portalUp, &nextDir, PORTAL_COVER_HEIGHT_RADIUS * 0.5f);
+    vector3Scale(&portalUp, &nextDir, PORTAL_COVER_HEIGHT_RADIUS);
     box3DExtendDirection(bb, &nextDir, bb);
     vector3Negate(&nextDir, &nextDir);
     box3DExtendDirection(bb, &nextDir, bb);
 
-    vector3Scale(&portalRight, &nextDir, PORTAL_COVER_WIDTH_RADIUS * 0.5f);
+    vector3Scale(&portalRight, &nextDir, PORTAL_COVER_WIDTH_RADIUS);
     box3DExtendDirection(bb, &nextDir, bb);
     vector3Negate(&nextDir, &nextDir);
     box3DExtendDirection(bb, &nextDir, bb);

--- a/src/scene/portal.c
+++ b/src/scene/portal.c
@@ -30,14 +30,14 @@ struct ColliderTypeData gPortalColliderType = {
 #define CALC_SCREEN_SPACE(clip_space, screen_size) ((clip_space + 1.0f) * ((screen_size) / 2))
 
 struct Vector3 gPortalOutline[PORTAL_LOOP_SIZE] = {
-    {0.0f, 1.0f * SCENE_SCALE * PORTAL_COVER_HEIGHT, 0},
-    {0.353553f * SCENE_SCALE * PORTAL_COVER_WIDTH, 0.707107f * SCENE_SCALE * PORTAL_COVER_HEIGHT, 0},
-    {0.5f * SCENE_SCALE * PORTAL_COVER_WIDTH, 0.0f, 0},
-    {0.353553f * SCENE_SCALE * PORTAL_COVER_WIDTH, -0.707107f * SCENE_SCALE * PORTAL_COVER_HEIGHT, 0},
-    {0.0f, -1.0f * SCENE_SCALE * PORTAL_COVER_HEIGHT, 0},
-    {-0.353553f * SCENE_SCALE * PORTAL_COVER_WIDTH, -0.707107f * SCENE_SCALE * PORTAL_COVER_HEIGHT, 0},
-    {-0.5f * SCENE_SCALE * PORTAL_COVER_WIDTH, 0.0f, 0},
-    {-0.353553f * SCENE_SCALE * PORTAL_COVER_WIDTH, 0.707107f * SCENE_SCALE * PORTAL_COVER_HEIGHT, 0},
+    {0.0f, 1.0f * SCENE_SCALE * PORTAL_COVER_HEIGHT_RADIUS, 0},
+    {SCENE_SCALE * PORTAL_COVER_WIDTH_RADIUS, SCENE_SCALE * PORTAL_COVER_HEIGHT_RADIUS, 0},
+    {0.5f * SCENE_SCALE * PORTAL_COVER_WIDTH_RADIUS, 0.0f, 0},
+    {SCENE_SCALE * PORTAL_COVER_WIDTH_RADIUS, -1.0f * SCENE_SCALE * PORTAL_COVER_HEIGHT_RADIUS, 0},
+    {0.0f, -1.0f * SCENE_SCALE * PORTAL_COVER_HEIGHT_RADIUS, 0},
+    {-1.0f * SCENE_SCALE * PORTAL_COVER_WIDTH_RADIUS, -1.0f * SCENE_SCALE * PORTAL_COVER_HEIGHT_RADIUS, 0},
+    {-0.5f * SCENE_SCALE * PORTAL_COVER_WIDTH_RADIUS, 0.0f, 0},
+    {-1.0f * SCENE_SCALE * PORTAL_COVER_WIDTH_RADIUS, SCENE_SCALE * PORTAL_COVER_HEIGHT_RADIUS, 0},
 };
 
 #define PORTAL_CLIPPING_PLANE_BIAS  (SCENE_SCALE * 0.25f)
@@ -86,12 +86,12 @@ void portalCalculateBB(struct Transform* portalTransform, struct Box3D* bb) {
     bb->min = bb->max = portalTransform->position;
 
     struct Vector3 nextDir;
-    vector3Scale(&portalUp, &nextDir, PORTAL_COVER_HEIGHT * 0.5f);
+    vector3Scale(&portalUp, &nextDir, PORTAL_COVER_HEIGHT_RADIUS * 0.5f);
     box3DExtendDirection(bb, &nextDir, bb);
     vector3Negate(&nextDir, &nextDir);
     box3DExtendDirection(bb, &nextDir, bb);
 
-    vector3Scale(&portalRight, &nextDir, PORTAL_COVER_WIDTH * 0.5f);
+    vector3Scale(&portalRight, &nextDir, PORTAL_COVER_WIDTH_RADIUS * 0.5f);
     box3DExtendDirection(bb, &nextDir, bb);
     vector3Negate(&nextDir, &nextDir);
     box3DExtendDirection(bb, &nextDir, bb);

--- a/src/scene/render_plan.c
+++ b/src/scene/render_plan.c
@@ -266,7 +266,7 @@ int renderPlanPortal(struct RenderPlan* renderPlan, struct Scene* scene, struct 
     struct Vector3 cameraForward;
     quatMultVector(&next->camera.transform.rotation, &gForward, &cameraForward);
 
-    next->camera.nearPlane = (-vector3Dot(&portalOffset, &cameraForward)) * SCENE_SCALE - SCENE_SCALE * PORTAL_COVER_HEIGHT_RADIUS * 0.5f;
+    next->camera.nearPlane = (-vector3Dot(&portalOffset, &cameraForward)) * SCENE_SCALE - SCENE_SCALE * PORTAL_COVER_HEIGHT_RADIUS;
 
     if (next->camera.nearPlane < current->camera.nearPlane) {
         next->camera.nearPlane = current->camera.nearPlane;

--- a/src/scene/render_plan.c
+++ b/src/scene/render_plan.c
@@ -266,7 +266,7 @@ int renderPlanPortal(struct RenderPlan* renderPlan, struct Scene* scene, struct 
     struct Vector3 cameraForward;
     quatMultVector(&next->camera.transform.rotation, &gForward, &cameraForward);
 
-    next->camera.nearPlane = (-vector3Dot(&portalOffset, &cameraForward)) * SCENE_SCALE - SCENE_SCALE * PORTAL_COVER_HEIGHT * 0.5f;
+    next->camera.nearPlane = (-vector3Dot(&portalOffset, &cameraForward)) * SCENE_SCALE - SCENE_SCALE * PORTAL_COVER_HEIGHT_RADIUS * 0.5f;
 
     if (next->camera.nearPlane < current->camera.nearPlane) {
         next->camera.nearPlane = current->camera.nearPlane;


### PR DESCRIPTION
- I am not really sure if this is the exact value you were going for with this, but 1.6 seems to match the collision to the top and bottom of the portal cutout.
- larger items like boxes seem to pass through much easier now.
- have not seen any negative side effect from this.

Fixes #294
also seems to fix the following now:
Fixes #260