### PR TITLE
Made Elevator to Wait for Voicelines to Move

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,10 +187,10 @@ That will generate the rom at `/build/portal64.z64`
 <br />
 
 ## Current New Feature TODO List
-- [ ] polish up subtitles
-- [ ] more sound settings
 - [ ] rumble pak support
 - [ ] pausing while glados is speaking can end her speech early
+- [x] polish up subtitles
+- [x] more sound settings
 - [x] add desk chairs and monitors
 - [x] Add auto save checkpoints
 - [x] Correct elevator timing
@@ -204,6 +204,4 @@ That will generate the rom at `/build/portal64.z64`
 ----------------------- v8
 - [ ] Two wall portals next to eachother can be used to clip any object out of any level by pushing it into corner, then dropping. 
 - [ ] Passing into a ceiling portal can sometimes mess with the player rotation
-- [ ] various visual glitches when running NTSC on PAL console #65
-- [ ] various visual glitches when running PAL on NTSC console #65
 - [x] player can clip through back of elevator by jumping and strafeing at the back corners while inside.

--- a/src/levels/cutscene_runner.c
+++ b/src/levels/cutscene_runner.c
@@ -589,3 +589,14 @@ void cutsceneQueueSoundInChannel(int soundId, float volume, int channel, int sub
 
     cutsceneQueueSound(soundId, volume, channel, subtitleId);
 }
+
+int cutsceneIsSoundQueued(){
+    int soundQueued = 0;
+    for (int i = 0; i < CH_COUNT; ++i) {
+        if(gCutsceneSoundQueues[i] != NULL || gCutsceneCurrentSound[i] != SOUND_ID_NONE){
+            soundQueued = 1;
+            break;
+        }
+    }
+    return soundQueued;
+}

--- a/src/levels/cutscene_runner.h
+++ b/src/levels/cutscene_runner.h
@@ -44,5 +44,6 @@ void cutsceneSerializeRead(struct Serializer* serializer);
 
 int cutsceneRunnerIsChannelPlaying(int channel);
 void cutsceneQueueSoundInChannel(int soundId, float volume, int channel, int subtitleId);
+int cutsceneIsSoundQueued();
 
 #endif

--- a/src/scene/elevator.c
+++ b/src/scene/elevator.c
@@ -22,8 +22,8 @@
 #define OPEN_SPEED              2.0f
 
 #define OPEN_DELAY              1.0f
-#define CLOSE_DELAY             13.0f
-#define MOVING_SOUND_DELAY      3.5f  
+#define CLOSE_DELAY             10.0f
+#define MOVING_SOUND_DELAY      1.5f  
 #define SHAKE_DURATION          0.5f    
 
 struct ColliderTypeData gElevatorColliderType = {
@@ -129,7 +129,7 @@ int elevatorUpdate(struct Elevator* elevator, struct Player* player) {
     short result = -1;
 
     if (elevator->flags & ElevatorFlagsIsExit) {
-        if (inside) {
+        if (inside && !(gScene.boolCutsceneIsRunning)) {
             elevator->timer -= FIXED_DELTA_TIME;
         }
 
@@ -139,7 +139,7 @@ int elevatorUpdate(struct Elevator* elevator, struct Player* player) {
         shouldBeOpen = inRange && !inside;
         shouldLock = inside;
         
-        if (inside || (elevator->flags & ElevatorFlagsIsLocked) != 0) {
+        if ((inside || (elevator->flags & ElevatorFlagsIsLocked) != 0) && !(gScene.boolCutsceneIsRunning)) {
             elevator->timer -= FIXED_DELTA_TIME;
 
             if (elevator->timer < 0.0f) {
@@ -191,11 +191,11 @@ int elevatorUpdate(struct Elevator* elevator, struct Player* player) {
     }
     
 
-    if ((elevator->flags & ElevatorFlagsIsLocked) && (elevator->openAmount == 0.0f) && (elevator->movingTimer > 0.0f)){
+    if ((elevator->flags & ElevatorFlagsIsLocked) && (elevator->openAmount == 0.0f) && (elevator->movingTimer > 0.0f) && !(gScene.boolCutsceneIsRunning)){
         elevator->movingTimer -= FIXED_DELTA_TIME;
     }
 
-    if ((elevator->flags & ElevatorFlagsIsLocked) && (elevator->openAmount == 0.0f) && !(elevator->flags & ElevatorFlagsMovingSoundPlayed) && (elevator->movingTimer <= 0.0f) && inside){
+    if ((elevator->flags & ElevatorFlagsIsLocked) && (elevator->openAmount == 0.0f) && !(elevator->flags & ElevatorFlagsMovingSoundPlayed) && (elevator->movingTimer <= 0.0f) && inside && !(gScene.boolCutsceneIsRunning)){
             soundPlayerPlay(soundsElevatorMoving, 1.25f, 0.5f, &elevator->rigidBody.transform.position, &gZeroVec, SoundTypeAll);
             hudShowSubtitle(&gScene.hud, PORTAL_ELEVATOR_START, SubtitleTypeCaption);
             player->shakeTimer = SHAKE_DURATION;

--- a/src/scene/elevator.c
+++ b/src/scene/elevator.c
@@ -122,14 +122,15 @@ int elevatorUpdate(struct Elevator* elevator, struct Player* player) {
 
     int inRange = horizontalDistance < AUTO_OPEN_DISTANCE * AUTO_OPEN_DISTANCE && verticalDistance < SAME_LEVEL_HEIGHT;
     int inside = horizontalDistance < INSIDE_DISTANCE * INSIDE_DISTANCE && verticalDistance < SAME_LEVEL_HEIGHT;
+    int cutscenePreventingMovement = ((gScene.boolCutsceneIsRunning==1) && (elevator->targetElevator >= gScene.elevatorCount));
 
     int shouldBeOpen;
     int shouldLock;
 
     short result = -1;
 
-    if (elevator->flags & ElevatorFlagsIsExit) {
-        if (inside && !(gScene.boolCutsceneIsRunning)) {
+    if ((elevator->flags & ElevatorFlagsIsExit) && !cutscenePreventingMovement) {
+        if (inside) {
             elevator->timer -= FIXED_DELTA_TIME;
         }
 
@@ -139,7 +140,7 @@ int elevatorUpdate(struct Elevator* elevator, struct Player* player) {
         shouldBeOpen = inRange && !inside;
         shouldLock = inside;
         
-        if ((inside || (elevator->flags & ElevatorFlagsIsLocked) != 0) && !(gScene.boolCutsceneIsRunning)) {
+        if ((inside || (elevator->flags & ElevatorFlagsIsLocked) != 0) && !cutscenePreventingMovement) {
             elevator->timer -= FIXED_DELTA_TIME;
 
             if (elevator->timer < 0.0f) {
@@ -191,11 +192,11 @@ int elevatorUpdate(struct Elevator* elevator, struct Player* player) {
     }
     
 
-    if ((elevator->flags & ElevatorFlagsIsLocked) && (elevator->openAmount == 0.0f) && (elevator->movingTimer > 0.0f) && !(gScene.boolCutsceneIsRunning)){
+    if ((elevator->flags & ElevatorFlagsIsLocked) && (elevator->openAmount == 0.0f) && (elevator->movingTimer > 0.0f) && !cutscenePreventingMovement){
         elevator->movingTimer -= FIXED_DELTA_TIME;
     }
 
-    if ((elevator->flags & ElevatorFlagsIsLocked) && (elevator->openAmount == 0.0f) && !(elevator->flags & ElevatorFlagsMovingSoundPlayed) && (elevator->movingTimer <= 0.0f) && inside && !(gScene.boolCutsceneIsRunning)){
+    if ((elevator->flags & ElevatorFlagsIsLocked) && (elevator->openAmount == 0.0f) && !(elevator->flags & ElevatorFlagsMovingSoundPlayed) && (elevator->movingTimer <= 0.0f) && !cutscenePreventingMovement){
             soundPlayerPlay(soundsElevatorMoving, 1.25f, 0.5f, &elevator->rigidBody.transform.position, &gZeroVec, SoundTypeAll);
             hudShowSubtitle(&gScene.hud, PORTAL_ELEVATOR_START, SubtitleTypeCaption);
             player->shakeTimer = SHAKE_DURATION;

--- a/src/scene/elevator.h
+++ b/src/scene/elevator.h
@@ -5,6 +5,7 @@
 #include "../physics/collision_object.h"
 #include "../player/player.h"
 #include "../levels/level_definition.h"
+#include "../scene/scene.h"
 
 enum ElevatorFlags {
     ElevatorFlagsIsLocked = (1 << 0),

--- a/src/scene/scene.c
+++ b/src/scene/scene.c
@@ -244,6 +244,7 @@ void sceneInitNoPauseMenu(struct Scene* scene, int mainMenuMode) {
     }
 
     scene->continuouslyAttemptingPortalOpen=0;
+    scene->boolCutsceneIsRunning=0;
     scene->checkpointState = SceneCheckpointStateSaved;
 
     scene->freeCameraOffset = gZeroVec;
@@ -528,6 +529,8 @@ void sceneUpdateAnimatedObjects(struct Scene* scene) {
 }
 
 void sceneUpdate(struct Scene* scene) {
+    scene->boolCutsceneIsRunning = cutsceneIsSoundQueued();
+
     if (scene->checkpointState == SceneCheckpointStateReady) {
         checkpointSave(scene);
         scene->checkpointState = SceneCheckpointStateSaved;

--- a/src/scene/scene.h
+++ b/src/scene/scene.h
@@ -82,6 +82,7 @@ struct Scene {
     u8 ballCatcherCount;
     u8 clockCount;
     u8 securityCameraCount;
+    u8 boolCutsceneIsRunning;
 
     u8 continuouslyAttemptingPortalOpen;
     u8 checkpointState;


### PR DESCRIPTION
- made elevator wait for voicelines to finish
- I made this the case on all levels because I watched the elevator sequences on all levels of a playthrough and it always seemed to wait.

Fixes #217

https://github.com/lambertjamesd/portal64/assets/71656782/b56a0ada-0417-474e-a1ef-99862200c218

