### PR TITLE
Fizzler is Anti-Portal

### DIFF
--- a/src/physics/collision_scene.c
+++ b/src/physics/collision_scene.c
@@ -398,7 +398,7 @@ void collisionSceneRaycastDynamic(struct CollisionScene* scene, struct Ray* ray,
 
         struct CollisionObject* object = scene->dynamicObjects[i];
 
-        if ((object->collisionLayers & collisionLayers) == 0 || object->trigger != NULL) {
+        if ((object->collisionLayers & collisionLayers) == 0 || (object->trigger != NULL && !(object->collisionLayers & COLLISION_LAYERS_FIZZLER)) ) {
             continue;
         }
 


### PR DESCRIPTION
- simply added a check to see if an object has a COLLISION_LAYER_FIZZLER, if so it cant shoot a portal past.

Fixes part of #300 