### PR TITLE
Made Player Movement Match Moving Platforms

### DIFF
--- a/src/player/player.h
+++ b/src/player/player.h
@@ -44,6 +44,8 @@ struct Player {
     float yawVelocity;
     enum PlayerFlags flags;
     struct RigidBody* anchoredTo;
+    struct Vector3 lastAnchorToPosition;
+    struct Vector3 lastAnchorToVelocity;
     struct Vector3 relativeAnchor;
     struct Vector3 lastAnchorPoint;
     short flyingSoundLoopId;


### PR DESCRIPTION
- store the velocity of a moving object that player is anchored to and apply that to player movement
- player now keeps up with horizontal movement while jumping on moving platform

Fixes #300

https://github.com/lambertjamesd/portal64/assets/71656782/d42f4a50-b021-4068-a3f6-18ea95cbca60

