### PR TITLE
Various little menu improvements

### DIFF
--- a/src/menu/audio_options.c
+++ b/src/menu/audio_options.c
@@ -126,6 +126,7 @@ enum MenuDirection audioOptionsUpdate(struct AudioOptions* audioOptions) {
         if (audioOptions->selectedItem == AudioOptionCount) {
             audioOptions->selectedItem = 0;
         }
+        soundPlayerPlay(SOUNDS_BUTTONROLLOVER, 1.0f, 0.5f, NULL, NULL, SoundTypeAll);
     }
 
     if (controllerDir & ControllerDirectionUp) {
@@ -134,6 +135,7 @@ enum MenuDirection audioOptionsUpdate(struct AudioOptions* audioOptions) {
         } else {
             --audioOptions->selectedItem;
         }
+        soundPlayerPlay(SOUNDS_BUTTONROLLOVER, 1.0f, 0.5f, NULL, NULL, SoundTypeAll);
     }
 
     switch (audioOptions->selectedItem) {

--- a/src/menu/controls.c
+++ b/src/menu/controls.c
@@ -296,6 +296,7 @@ enum MenuDirection controlsMenuUpdate(struct ControlsMenu* controlsMenu) {
         if (controlsMenu->selectedRow == ControllerActionCount + 1) {
             controlsMenu->selectedRow = 0;
         }
+        soundPlayerPlay(SOUNDS_BUTTONROLLOVER, 1.0f, 0.5f, NULL, NULL, SoundTypeAll);
     }
 
     if (controllerDir & ControllerDirectionUp) {
@@ -304,6 +305,7 @@ enum MenuDirection controlsMenuUpdate(struct ControlsMenu* controlsMenu) {
         if (controlsMenu->selectedRow < 0) {
             controlsMenu->selectedRow = ControllerActionCount;
         }
+        soundPlayerPlay(SOUNDS_BUTTONROLLOVER, 1.0f, 0.5f, NULL, NULL, SoundTypeAll);
     }
 
     if (controlsMenu->selectedRow >= 0 && controlsMenu->selectedRow < ControllerActionCount) {

--- a/src/menu/gameplay_options.c
+++ b/src/menu/gameplay_options.c
@@ -83,6 +83,7 @@ enum MenuDirection gameplayOptionsUpdate(struct GameplayOptions* gameplayOptions
         if (gameplayOptions->selectedItem == GameplayOptionCount) {
             gameplayOptions->selectedItem = 0;
         }
+        soundPlayerPlay(SOUNDS_BUTTONROLLOVER, 1.0f, 0.5f, NULL, NULL, SoundTypeAll);
     }
 
     if (controllerDir & ControllerDirectionUp) {
@@ -91,6 +92,7 @@ enum MenuDirection gameplayOptionsUpdate(struct GameplayOptions* gameplayOptions
         } else {
             --gameplayOptions->selectedItem;
         }
+        soundPlayerPlay(SOUNDS_BUTTONROLLOVER, 1.0f, 0.5f, NULL, NULL, SoundTypeAll);
     }
 
     switch (gameplayOptions->selectedItem) {

--- a/src/menu/joystick_options.c
+++ b/src/menu/joystick_options.c
@@ -92,6 +92,7 @@ enum MenuDirection joystickOptionsUpdate(struct JoystickOptions* joystickOptions
         if (joystickOptions->selectedItem == JoystickOptionCount) {
             joystickOptions->selectedItem = 0;
         }
+        soundPlayerPlay(SOUNDS_BUTTONROLLOVER, 1.0f, 0.5f, NULL, NULL, SoundTypeAll);
     }
 
     if (controllerDir & ControllerDirectionUp) {
@@ -100,6 +101,7 @@ enum MenuDirection joystickOptionsUpdate(struct JoystickOptions* joystickOptions
         } else {
             --joystickOptions->selectedItem;
         }
+        soundPlayerPlay(SOUNDS_BUTTONROLLOVER, 1.0f, 0.5f, NULL, NULL, SoundTypeAll);
     }
 
     switch (joystickOptions->selectedItem) {

--- a/src/menu/landing_menu.c
+++ b/src/menu/landing_menu.c
@@ -71,13 +71,21 @@ void landingMenuInit(struct LandingMenu* landingMenu, struct LandingMenuOption* 
 }
 
 struct LandingMenuOption* landingMenuUpdate(struct LandingMenu* landingMenu) {
-    if ((controllerGetDirectionDown(0) & ControllerDirectionUp) != 0 && landingMenu->selectedItem > 0) {
-        --landingMenu->selectedItem;
+    if ((controllerGetDirectionDown(0) & ControllerDirectionUp) != 0) {
+        if (landingMenu->selectedItem > 0) {
+            --landingMenu->selectedItem;
+        } else { 
+            landingMenu->selectedItem = landingMenu->optionCount - 1;
+        }
         soundPlayerPlay(SOUNDS_BUTTONROLLOVER, 1.0f, 0.5f, NULL, NULL, SoundTypeAll);
     }
 
-    if ((controllerGetDirectionDown(0) & ControllerDirectionDown) != 0 && landingMenu->selectedItem + 1 < landingMenu->optionCount) {
-        ++landingMenu->selectedItem;
+    if ((controllerGetDirectionDown(0) & ControllerDirectionDown) != 0) {
+        if (landingMenu->selectedItem + 1 < landingMenu->optionCount) {
+            ++landingMenu->selectedItem;
+        } else {
+            landingMenu->selectedItem = 0;
+        }
         soundPlayerPlay(SOUNDS_BUTTONROLLOVER, 1.0f, 0.5f, NULL, NULL, SoundTypeAll);
     }
 

--- a/src/menu/new_game_menu.c
+++ b/src/menu/new_game_menu.c
@@ -144,13 +144,14 @@ enum MenuDirection newGameUpdate(struct NewGameMenu* newGameMenu) {
         newGameMenu->selectedChapter + 1 < newGameMenu->chapterCount &&
         gChapters[newGameMenu->selectedChapter + 1].imageData) {
         newGameMenu->selectedChapter = newGameMenu->selectedChapter + 1;
-        soundPlayerPlay(SOUNDS_BUTTONROLLOVER, 1.0f, 0.5f, NULL, NULL, SoundTypeAll);
     }
 
     if ((controllerGetDirectionDown(0) & ControllerDirectionLeft) != 0 && newGameMenu->selectedChapter > 0) {
         newGameMenu->selectedChapter = newGameMenu->selectedChapter - 1;
-        soundPlayerPlay(SOUNDS_BUTTONROLLOVER, 1.0f, 0.5f, NULL, NULL, SoundTypeAll);
     }
+    
+    if ((controllerGetDirectionDown(0) & ControllerDirectionLeft) != 0 || (controllerGetDirectionDown(0) & ControllerDirectionRight) != 0)
+        soundPlayerPlay(SOUNDS_BUTTONROLLOVER, 1.0f, 0.5f, NULL, NULL, SoundTypeAll);
 
     int nextChapterOffset = newGameMenu->selectedChapter & ~1;
 

--- a/src/menu/options_menu.c
+++ b/src/menu/options_menu.c
@@ -8,6 +8,7 @@
 #include "../build/assets/materials/ui.h"
 
 #include "../controls/controller.h"
+#include "../build/src/audio/clips.h"
 
 
 struct Tab gOptionTabs[] = {
@@ -87,6 +88,7 @@ enum MenuDirection optionsMenuUpdate(struct OptionsMenu* options) {
         }
 
         tabsSetSelectedTab(&options->tabs, options->tabs.selectedTab);
+        soundPlayerPlay(SOUNDS_BUTTONROLLOVER, 1.0f, 0.5f, NULL, NULL, SoundTypeAll);
     }
 
     if (menuDirection == MenuDirectionRight) {
@@ -95,6 +97,7 @@ enum MenuDirection optionsMenuUpdate(struct OptionsMenu* options) {
         } else {
             tabsSetSelectedTab(&options->tabs, options->tabs.selectedTab + 1);
         }
+        soundPlayerPlay(SOUNDS_BUTTONROLLOVER, 1.0f, 0.5f, NULL, NULL, SoundTypeAll);
 
     }
 


### PR DESCRIPTION
- This adds the BUTTONROLLOVER sound (from switching main menu items) to the options menu as well (for options + tabs).
- Also enables main & game menu to cycle through the items when moving only up or down (like in the options menu)
- Also play this sound in the "new game menu", when only one item is selectable. The other menus like load/save play this sound as well, even when their lists only include one item. The "new game menu" lacked a bit in perceived responsiveness because of that.

I think this makes using the menu more consistent and feels better. :)

In the future, we could expand these code paths with rumble as well.