### PR TITLE
Fixes a save load crash and audio bug

### DIFF
--- a/src/audio/soundplayer.c
+++ b/src/audio/soundplayer.c
@@ -491,4 +491,5 @@ void soundPlayerResume() {
             alSndpSetVol(&gSoundPlayer, (short)(32767 * activeSound->volume));
         }
     }
+    soundPlayerGameVolumeUpdate();
 }

--- a/src/levels/cutscene_runner.c
+++ b/src/levels/cutscene_runner.c
@@ -544,6 +544,7 @@ void cutsceneSerializeWrite(struct Serializer* serializer, SerializeAction actio
 
         while (curr) {
             action(serializer, &curr->soundId, sizeof(u16));
+            action(serializer, &curr->subtitleId, sizeof(s16));
             u8 volume = (u8)(clampf(curr->volume, 0.0f, 1.0f) * 255.0f);
             action(serializer, &volume, sizeof(volume));
             curr = curr->next;

--- a/src/levels/levels.c
+++ b/src/levels/levels.c
@@ -125,6 +125,7 @@ void levelLoad(int index) {
     gQueuedLevel = NO_QUEUED_LEVEL;
 
     collisionSceneInit(&gCollisionScene, gCurrentLevel->collisionQuads, gCurrentLevel->collisionQuadCount, &gCurrentLevel->world);
+    soundPlayerResume();
 }
 
 void levelQueueLoad(int index, struct Transform* relativeExitTransform, struct Vector3* relativeVelocity) {
@@ -156,7 +157,7 @@ void levelLoadLastCheckpoint() {
     gQueuedLevel = gCurrentLevelIndex;
     transformInitIdentity(&gRelativeTransform);
     gRelativeTransform.position.y = PLAYER_HEAD_HEIGHT;
-    gRelativeVelocity = gZeroVec;
+    gRelativeVelocity = gZeroVec;  
 }
 
 int levelGetQueued() {

--- a/src/levels/levels.c
+++ b/src/levels/levels.c
@@ -157,7 +157,7 @@ void levelLoadLastCheckpoint() {
     gQueuedLevel = gCurrentLevelIndex;
     transformInitIdentity(&gRelativeTransform);
     gRelativeTransform.position.y = PLAYER_HEAD_HEIGHT;
-    gRelativeVelocity = gZeroVec;  
+    gRelativeVelocity = gZeroVec;
 }
 
 int levelGetQueued() {

--- a/src/menu/save_game_menu.c
+++ b/src/menu/save_game_menu.c
@@ -5,7 +5,6 @@
 #include "../controls/controller.h"
 #include "../util/memory.h"
 #include "../audio/soundplayer.h"
-#include "../levels/cutscene_runner.h"
 
 #include "../build/src/audio/clips.h"
 

--- a/src/menu/save_game_menu.c
+++ b/src/menu/save_game_menu.c
@@ -60,7 +60,7 @@ void saveGamePopulate(struct SaveGameMenu* saveGame, int includeNew) {
 enum MenuDirection saveGameUpdate(struct SaveGameMenu* saveGame) {
     if (controllerGetButtonDown(0, A_BUTTON) && saveGame->savefileList->numberOfSaves) {
         Checkpoint* save = stackMalloc(MAX_CHECKPOINT_SIZE);
-        if (!cutsceneIsSoundQueued() && checkpointSaveInto(&gScene, save)) {
+        if (checkpointSaveInto(&gScene, save)) {
             savefileSaveGame(save, gScreenGrabBuffer, levelGetChamberNumber(gCurrentLevelIndex, gScene.player.body.currentRoom), gCurrentTestSubject, savefileGetSlot(saveGame->savefileList));
             saveGamePopulate(saveGame, 0);
             soundPlayerPlay(SOUNDS_BUTTONCLICKRELEASE, 1.0f, 0.5f, NULL, NULL, SoundTypeAll);

--- a/src/menu/save_game_menu.c
+++ b/src/menu/save_game_menu.c
@@ -5,6 +5,7 @@
 #include "../controls/controller.h"
 #include "../util/memory.h"
 #include "../audio/soundplayer.h"
+#include "../levels/cutscene_runner.h"
 
 #include "../build/src/audio/clips.h"
 
@@ -59,12 +60,14 @@ void saveGamePopulate(struct SaveGameMenu* saveGame, int includeNew) {
 enum MenuDirection saveGameUpdate(struct SaveGameMenu* saveGame) {
     if (controllerGetButtonDown(0, A_BUTTON) && saveGame->savefileList->numberOfSaves) {
         Checkpoint* save = stackMalloc(MAX_CHECKPOINT_SIZE);
-        if (checkpointSaveInto(&gScene, save)) {
+        if (!cutsceneIsSoundQueued() && checkpointSaveInto(&gScene, save)) {
             savefileSaveGame(save, gScreenGrabBuffer, levelGetChamberNumber(gCurrentLevelIndex, gScene.player.body.currentRoom), gCurrentTestSubject, savefileGetSlot(saveGame->savefileList));
             saveGamePopulate(saveGame, 0);
+            soundPlayerPlay(SOUNDS_BUTTONCLICKRELEASE, 1.0f, 0.5f, NULL, NULL, SoundTypeAll);
+        }else{
+            soundPlayerPlay(SOUNDS_WPN_DENYSELECT, 1.0f, 0.5f, NULL, NULL, SoundTypeAll);
         }
         stackMallocFree(save);
-        soundPlayerPlay(SOUNDS_BUTTONCLICKRELEASE, 1.0f, 0.5f, NULL, NULL, SoundTypeAll);
     }
 
     return savefileListUpdate(saveGame->savefileList);


### PR DESCRIPTION
- if the game was saved while the cutscene runner had queued audio lines, when that save was loaded it would crash the game.
- to alleviate I simply deny the player to save while a cutscene audio is queued with the "deny" sound.
- also relieved a bug where audio volume would not be correct after loading a save, by simply updating the volume when a queued level is loaded.

we could probably find the true solution to this crash and allow players to save during a cutscene, however I think this workaround is good for now to avoid crashes.