### PR TITLE
Fix crash chamber 06 when reloading after ball death

### DIFF
--- a/assets/test_chambers/test_chamber_03/test_chamber_03.yaml
+++ b/assets/test_chambers/test_chamber_03/test_chamber_03.yaml
@@ -18,6 +18,7 @@ cutscenes:
     - q_sound 03_PART2_PLATFORM_ACTIVATED_1 CH_GLADOS PORTAL_03_PART2_PLATFORM_ACTIVATED_1
   INTRO:
     - save_checkpoint 0
+    - delay 2
     - open_portal ground_portal 0
     - q_sound SOUNDS_03_PART1_ENTRY_1 CH_GLADOS PORTAL_03_PART1_ENTRY_1
     - q_sound SOUNDS_03_PART1_ENTRY_2 CH_GLADOS PORTAL_03_PART1_ENTRY_2


### PR DESCRIPTION
- this crash was caused by having a checkpoint saved in the middle of a queued sound in the cutscene_runner, then trying to load that checkpoint after dying from the ball.
- I simply put a small delay before the q_sound in the levels yaml file so that the checkpoint is saved before the voicelines start.