### PR TITLE
Fix Door Object Collision Issue

### DIFF
--- a/src/physics/world.c
+++ b/src/physics/world.c
@@ -28,6 +28,10 @@ int worldCheckDoorwayCrossings(struct World* world, struct Vector3* position, in
     for (int i = 0; i < room->doorwayCount; ++i) {
         struct Doorway* doorway = &world->doorways[room->doorwayIndices[i]];
 
+        // extend the door plane a bit further to guarantee objects make contact
+        doorway->quad.edgeALength += 1.0f;
+        doorway->quad.edgeBLength += 1.0f;
+
         int prevSide = (sideMask & (1 << i)) != 0;
         int currSide = planePointDistance(&doorway->quad.plane, position) > 0;
 

--- a/src/physics/world.c
+++ b/src/physics/world.c
@@ -28,10 +28,6 @@ int worldCheckDoorwayCrossings(struct World* world, struct Vector3* position, in
     for (int i = 0; i < room->doorwayCount; ++i) {
         struct Doorway* doorway = &world->doorways[room->doorwayIndices[i]];
 
-        // extend the door plane a bit further to guarantee objects make contact
-        doorway->quad.edgeALength += 1.0f;
-        doorway->quad.edgeBLength += 1.0f;
-
         int prevSide = (sideMask & (1 << i)) != 0;
         int currSide = planePointDistance(&doorway->quad.plane, position) > 0;
 

--- a/tools/level_scripts/world.lua
+++ b/tools/level_scripts/world.lua
@@ -33,6 +33,10 @@ for doorway_index, doorway in pairs(sk_scene.nodes_for_type('@doorway')) do
     table.insert(room_doorways[room_a + 1], doorway_index - 1)
     table.insert(room_doorways[room_b + 1], doorway_index - 1)
 
+    quad.corner = quad.corner + (-0.5 * quad.edgeA + -0.5 * quad.edgeB)
+    quad.edgeALength = quad.edgeALength + 1.0
+    quad.edgeBLength = quad.edgeBLength + 1.0
+
     table.insert(doorways, {
         quad,
         room_a,


### PR DESCRIPTION
- simply extended the door `quad` while checking for `rigidbody` doorway passing

Fixes #344