### PR TITLE
Fixes Player Clipping Issues

### DIFF
--- a/src/player/player.c
+++ b/src/player/player.c
@@ -171,7 +171,7 @@ void playerInit(struct Player* player, struct Location* startLocation, struct Ve
     dynamicSceneSetRoomFlags(player->dynamicId, ROOM_FLAG_FROM_INDEX(player->body.currentRoom));
 }
 
-#define PLAYER_SPEED    (150.0f / 64.0f)
+#define PLAYER_SPEED    (150.0f / 50.0f)
 #define PLAYER_ACCEL    (5.875f)
 #define PLAYER_AIR_ACCEL    (5.875f)
 #define PLAYER_STOP_ACCEL    (5.875f)
@@ -698,6 +698,10 @@ void playerUpdate(struct Player* player) {
     }
 
     if (!isDead) {
+        if (fabsf(moveInput.x)+fabsf(moveInput.y) > 1.0f){
+            vector2Normalize(&moveInput, &moveInput);
+        }
+
         vector3AddScaled(&targetVelocity, &right, PLAYER_SPEED * moveInput.x, &targetVelocity);
         vector3AddScaled(&targetVelocity, &forward, -PLAYER_SPEED * moveInput.y, &targetVelocity);
 
@@ -756,13 +760,6 @@ void playerUpdate(struct Player* player) {
     playerUpdateSpeedSound(player);
 
     if (!(player->flags & PlayerFlagsGrounded)) {
-        if (isFast) {
-            struct Vector3 movementCenter;
-            vector3Scale(&player->body.velocity, &movementCenter, -PLAYER_SPEED / sqrtf(velocitySqrd));
-            targetVelocity.x += player->body.velocity.x + movementCenter.x;
-            targetVelocity.z += player->body.velocity.z + movementCenter.z;
-        }
-
         acceleration = PLAYER_AIR_ACCEL * FIXED_DELTA_TIME;
     } else if (isFast) {
         acceleration = PLAYER_SLIDE_ACCEL * FIXED_DELTA_TIME;

--- a/src/player/player.c
+++ b/src/player/player.c
@@ -173,7 +173,7 @@ void playerInit(struct Player* player, struct Location* startLocation, struct Ve
 
 #define PLAYER_SPEED    (150.0f / 64.0f)
 #define PLAYER_ACCEL    (5.875f)
-#define PLAYER_AIR_ACCEL    (5.875f)
+#define PLAYER_AIR_ACCEL    (1.875f)
 #define PLAYER_STOP_ACCEL    (5.875f)
 #define PLAYER_SLIDE_ACCEL    (40.0f)
 

--- a/src/player/player.c
+++ b/src/player/player.c
@@ -171,7 +171,7 @@ void playerInit(struct Player* player, struct Location* startLocation, struct Ve
     dynamicSceneSetRoomFlags(player->dynamicId, ROOM_FLAG_FROM_INDEX(player->body.currentRoom));
 }
 
-#define PLAYER_SPEED    (150.0f / 50.0f)
+#define PLAYER_SPEED    (150.0f / 64.0f)
 #define PLAYER_ACCEL    (5.875f)
 #define PLAYER_AIR_ACCEL    (5.875f)
 #define PLAYER_STOP_ACCEL    (5.875f)
@@ -698,7 +698,7 @@ void playerUpdate(struct Player* player) {
     }
 
     if (!isDead) {
-        if (fabsf(moveInput.x)+fabsf(moveInput.y) > 1.0f){
+        if (vector2MagSqr(&moveInput) > 1.0f){
             vector2Normalize(&moveInput, &moveInput);
         }
 


### PR DESCRIPTION
Fixes #139

- this fixes player clipping through doors, and out of elevator.
- I made the x and y normalized so that the player doesnt go faster while holding down forward x and forward y
- this made movement a bit slower so I increased PLAYER_SPEED a bit
- also removed a is_fast if statment. this seems to be the primary code that was allowing for the clipping.

https://github.com/lambertjamesd/portal64/assets/71656782/f2c23035-890e-4e86-8cd3-792ecb2237e2