### PR TITLE
don't render empty subtitles

### DIFF
--- a/src/menu/controls.c
+++ b/src/menu/controls.c
@@ -514,6 +514,11 @@ void controlsRenderPrompt(enum ControllerAction action, char* message, float opa
 }
 
 void controlsRenderSubtitle(char* message, float textOpacity, float backgroundOpacity, struct RenderState* renderState, enum SubtitleType subtitleType) {
+    
+    if ((message != NULL) && (message[0] == '\0')) {
+       return;
+    }
+    
     struct FontRenderer* fontRender = stackMalloc(sizeof(struct FontRenderer));
     fontRendererLayout(fontRender, &gDejaVuSansFont, message, SCREEN_WD - (SUBTITLE_SIDE_MARGIN + SUBTITLE_PADDING) * 2);
 

--- a/src/menu/controls.c
+++ b/src/menu/controls.c
@@ -514,10 +514,8 @@ void controlsRenderPrompt(enum ControllerAction action, char* message, float opa
 }
 
 void controlsRenderSubtitle(char* message, float textOpacity, float backgroundOpacity, struct RenderState* renderState, enum SubtitleType subtitleType) {
-    
-    if ((message != NULL) && (message[0] == '\0')) {
+    if (message == NULL || (message != NULL && message[0] == '\0'))
        return;
-    }
     
     struct FontRenderer* fontRender = stackMalloc(sizeof(struct FontRenderer));
     fontRendererLayout(fontRender, &gDejaVuSansFont, message, SCREEN_WD - (SUBTITLE_SIDE_MARGIN + SUBTITLE_PADDING) * 2);


### PR DESCRIPTION
It seems not every language has every message id filled, e.g. subtitle 176 for danish, french, german, latam, norwegian, spanish - there is no text after the "bzzzzt" sound in the intro:

![278865796-4e6e6542-6d0b-4c5e-8c88-32c410d2fd01](https://github.com/lambertjamesd/portal64/assets/54060/95cd4740-7e19-4b9e-bef3-ad99d5f6c818)

This fixes this by not displaying empty subtitles.

Portal 1 on PC also displays a empty subtitle box though!
So if you want to stay true to the original game, you don't have to merge this, that would be fine as well.

But I think it looks strange, also I think this is a bug of Portal 1 AND a error in these affected translations.

All other translation include "Por favor bordón de fallar Muchos gracias de fallar gracias" for this line.
Except the turkish translation, which includes also a translation: "Por favor bordón de fallar Muchos gracias de fallar gracias (Lütfen başarısızlığa uğramaktan kaçının, çok teşekkürler)"

We also could just use the default subtitle line for these affected translations in the generation script instead.