### PR TITLE
Drops held item if raycast passes through two portals

### DIFF
--- a/src/physics/collision_scene.h
+++ b/src/physics/collision_scene.h
@@ -45,6 +45,7 @@ struct Transform* collisionSceneTransformToPortal(int fromPortal);
 void collisionScenePushObjectsOutOfPortal(int portalIndex);
 
 int collisionSceneRaycast(struct CollisionScene* scene, int roomIndex, struct Ray* ray, int collisionLayers, float maxDistance, int passThroughPortals, struct RaycastHit* hit);
+int collisionSceneRaycastCheckBothPortals(struct CollisionScene* scene, int roomIndex, struct Ray* ray, int collisionLayers, float maxDistance, int passThroughPortals, struct RaycastHit* hit);
 int collisionSceneRaycastOnlyDynamic(struct CollisionScene* scene, struct Ray* ray, int collisionLayers, float maxDistance, struct RaycastHit* hit);
 
 void collisionSceneGetPortalTransform(int fromPortal, struct Transform* out);


### PR DESCRIPTION
- added a new function to see if a raycast passes through both portals
- called this function from `player.c` and drops held object if the function returns a `1`
- ignore the name of the branch lol

Fixes #240


https://github.com/lambertjamesd/portal64/assets/71656782/97ff3a21-5da0-409b-af1b-a21f2e072cdb

