### PR TITLE
Implement "Advanced Homebrew ROM Header" for controller config

### DIFF
--- a/asm/rom_header.s
+++ b/asm/rom_header.s
@@ -15,7 +15,7 @@
 .word  0x00000000               /* Unknown */
 .word  0x00000000               /* Unknown */
 .ascii "                    "   /* Internal ROM name (Max 20 characters) */
-.word  0x00000000               /* Unknown */
+.word  0x01000000               /* Advanced_Homebrew_ROM_Header (controller config) */
 /* Game ID (EXAMPLE: NSME) Begins here */
 .word  0x0000004E                /* Cartridge Type (N)*/
 .ascii "ED"                     /* Cartridge ID (SM)*/


### PR DESCRIPTION
Database-driven emulators like ares did not correctly provide the rumble pack for rumble support for portal64.

I implemented the "Advanced Homebrew ROM Header" for this to configure Controller #1 with the rumble pack inserted.

https://n64brew.dev/wiki/ROM_Header#Advanced_Homebrew_ROM_Header

The only emulators supporting this at the moment are "Parallel Launcher" and "ares" after my PR https://github.com/ares-emulator/ares/pull/1286 was accepted.

