### PR TITLE
upgrade docker image to Ubuntu 23.04 to fix build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-from ubuntu:22.04
+from ubuntu:23.04
 
 WORKDIR /usr/src/app
 
@@ -30,6 +30,7 @@ RUN apt update -y && \
     libgl1 \
     python3 \
     pip \
+    pipx \
     imagemagick \
     libpng-dev \
     libtiff-dev \
@@ -56,4 +57,4 @@ RUN rm /opt/blender/blender-3.6.1-linux-x64.tar.xz
 
 ENV BLENDER_3_6 /opt/blender/blender-3.6.1-linux-x64/blender
 
-RUN pip install vpk
+RUN pipx install vpk


### PR DESCRIPTION
First time I tried to build portal64 with docker, I got libtiff6 errors while building skelatool - and this is not available on Ubuntu 22.04.

Upgrading the docker image to Ubuntu 23.04 fixed that :-)
Also we need "pipx" now (don't know because I do not know python3 :D )

Works fine now :-)