### PR TITLE
allow dynamic generation of subtitles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,10 +66,10 @@ LDFLAGS =	-L/usr/lib/n64 $(N64LIB)  -L$(N64_LIBGCCDIR) -lgcc
 
 default:	english_audio
 
-english_audio: portal_pak_dir
+english_audio: build/src/audio/subtitles.h portal_pak_dir
 	@$(MAKE) buildgame
 
-all_languages: portal_pak_dir german_audio french_audio russian_audio spanish_audio
+all_languages: build/src/audio/subtitles.h portal_pak_dir german_audio french_audio russian_audio spanish_audio
 	@$(MAKE) buildgame
 
 german_audio: vpk/portal_sound_vo_german_dir.vpk vpk/portal_sound_vo_german_000.vpk portal_pak_dir
@@ -501,35 +501,17 @@ build/src/decor/decor_object_list.o: build/src/audio/clips.h
 ## Subtitles
 ####################
 
-SUBTITLE_LANGUAGES = english \
-	brazilian \
-    bulgarian \
-    czech \
-    danish \
-    german \
-    spanish \
-    latam \
-	greek \
-    french \
-    italian \
-    polish \
-    hungarian \
-    dutch \
-    norwegian \
-    portuguese \
-    russian \
-    romanian \
-    finnish \
-    swedish \
-    turkish \
-	ukrainian
+SUBTITLE_SOURCES = $(shell find build/src/audio/ -type f -name 'subtitles_*.c')
+SUBTITLE_OBJECTS = $(patsubst %.c, %.o, $(SUBTITLE_SOURCES))
+	
+build/src/audio/subtitles_%.o: build/src/audio/subtitles_%.c
+	@mkdir -p $(@D)
+	$(CC) $(CFLAGS) -MM $^ -MF "$(@:.o=.d)" -MT"$@"
+	$(CC) $(CFLAGS) -c -o $@ $<
 
-SUBTITLE_SOURCES = $(SUBTITLE_LANGUAGES:%=build/src/audio/subtitles_%.c)
-SUBTITLE_OBJECTS = $(SUBTITLE_LANGUAGES:%=build/src/audio/subtitles_%.o)
-
-build/src/audio/subtitles.h build/src/audio/subtitles.c build/subtitles.ld $(SUBTITLE_SOURCES): vpk/Portal/portal/resource/closecaption_english.txt vpk/Portal/hl2/resource/gameui_english.txt vpk/Portal/hl2/resource/valve_english.txt assets/translations/extra_english.txt tools/level_scripts/subtitle_generate.py
-	python3 tools/level_scripts/subtitle_generate.py $(SUBTITLE_LANGUAGES)
-
+build/src/audio/subtitles.h build/src/audio/subtitles.c build/subtitles.ld: vpk/Portal/portal/resource/closecaption_english.txt vpk/Portal/hl2/resource/gameui_english.txt vpk/Portal/hl2/resource/valve_english.txt assets/translations/extra_english.txt tools/level_scripts/subtitle_generate.py
+	python3 tools/level_scripts/subtitle_generate.py
+	
 ####################
 ## Linking
 ####################

--- a/tools/generate_sound_ids.js
+++ b/tools/generate_sound_ids.js
@@ -11,8 +11,8 @@ let outputLanguagesSourceFile = '';
 let outputLanguagesHeader = '';
 let allSounds = [];
 let languages = [];
-let languages_codes = ["EN", "FR", "DE", "RU", "ES"];
-let language_names = {"EN": "English", "FR": "Français", "DE": "Deutsch", "RU": "Русский язык", "ES": "Español"};
+let languages_codes = ["EN", "DE", "ES", "FR", "RU"];
+let language_names = {"EN": "English", "DE": "Deutsch", "ES": "Español", "FR": "Français",  "RU": "Русский язык"};
 let lookup = [];
 languages.push("EN"); // Always included by default
 

--- a/tools/level_scripts/subtitle_generate.py
+++ b/tools/level_scripts/subtitle_generate.py
@@ -56,20 +56,20 @@ valve_whitelist = {
     "VALVE_MISCELLANEOUS_KEYBOARD_KEYS_TITLE",
 }
 
-#include only languages the font supports
-language_translations = {
-	'brazilian': 'Brasileiro',
+#include only languages the font supports (ingame lists display in this defined order)
+language_translations = {	
+    'english': 'English',
+    'brazilian': 'Brasileiro',
     'bulgarian': 'Български език',
     'czech': 'Čeština',
     'danish': 'Dansk',
     'german': 'Deutsch',
-    'english': 'English',
     'spanish': 'Español',
-	'greek': 'Ελληνικά',
+    'latam': 'Español americana',
+    'greek': 'Ελληνικά',
     'french': 'Français',
     'italian': 'Italiano',
     'polish': 'Język polski',
-    'latam': 'Español americana',
     'hungarian': 'Magyar nyelv',
     'dutch': 'Nederlands',
     'norwegian': 'Norsk',
@@ -79,7 +79,7 @@ language_translations = {
     'finnish': 'Suomi',
     'swedish': 'Svenska',
     'turkish': 'Türkçe',
-	'ukrainian': 'Українська мова',
+    'ukrainian': 'Українська мова',
 }
 
 def get_supported_characters():
@@ -405,6 +405,7 @@ dir = "vpk/Portal/portal/resource"
 
 #actually available supported languages
 available_languages_list = []
+ordered_language_list = []
 
 lst = os.listdir(dir)
 lst.sort()
@@ -414,4 +415,8 @@ for filename in lst:
             if language not in available_languages_list:
                 available_languages_list.append(language)
 
-process_all_closecaption_files(dir, available_languages_list)
+for language in language_translations:
+    if language in available_languages_list:
+        ordered_language_list.append(language)
+
+process_all_closecaption_files(dir, ordered_language_list)

--- a/tools/level_scripts/subtitle_generate.py
+++ b/tools/level_scripts/subtitle_generate.py
@@ -56,6 +56,7 @@ valve_whitelist = {
     "VALVE_MISCELLANEOUS_KEYBOARD_KEYS_TITLE",
 }
 
+#include only languages the font supports
 language_translations = {
 	'brazilian': 'Brasileiro',
     'bulgarian': 'Български език',
@@ -400,6 +401,17 @@ def process_all_closecaption_files(dir, language_names):
     make_overall_subtitles_header(header_lines, language_list, len(language_with_values_list[0]['value']), max_message_length)
     make_overall_subtitles_sourcefile(language_list)
 
+dir = "vpk/Portal/portal/resource"
 
+#actually available supported languages
+available_languages_list = []
 
-process_all_closecaption_files("vpk/Portal/portal/resource", sys.argv[1:])
+lst = os.listdir(dir)
+lst.sort()
+for filename in lst:
+    for language in language_translations:
+        if language in filename:
+            if language not in available_languages_list:
+                available_languages_list.append(language)
+
+process_all_closecaption_files(dir, available_languages_list)


### PR DESCRIPTION
allow dynamic generation of subtitles.
don't require all supported subtitle language files.

only english files are required for minimal/default build.

if you don't want to build with german text language, there can't be any "*german*" files in the resources folder - if only some are missing, and some exist, there will be a python exception.

fixes #476 