### PR TITLE
Update README.md (update Blender installation command to install version 3.6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ sudo apt install libnustd
 Next, you will need to download Blender 3.6.1 or higher. Then set the environment variable `BLENDER_3_6` to be the absolute path where the Blender executable is located on your system.
 
 ```sh
-sudo apt install blender
+sudo snap install blender --channel=3.6lts/stable --classic
 ```
 
 e.g. add this to your ~/.bashrc


### PR DESCRIPTION
Since the instructions (and the name of the `BLENDER_3_6` environment variable) specifically talk about LTS version 3.6.x, this command will probably be better than "sudo apt install blender" (which will install a random version, possibly not 3.6)

Command taken from here: https://snapcraft.io/blender -> "3.6lts/stable" from the upper right corner