### PR TITLE
Update README.md (only Blender 3.6 works, e.g. 4.x doesn't)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ After installing modern sdk you will want to also install
 sudo apt install libnustd
 ```
 
-Next, you will need to download Blender 3.6.1 or higher. Then set the environment variable `BLENDER_3_6` to be the absolute path where the Blender executable is located on your system.
+Next, you will need to install the latest version of Blender 3.6 LTS (please don't use e.g. 4.x, only 3.6.x will work correctly). Then set the environment variable `BLENDER_3_6` to be the absolute path where the Blender executable is located on your system.
 
 ```sh
 sudo apt install blender


### PR DESCRIPTION
I verified that only Blender 3.6.x works correctly: Blender 4.0.1 produced a corrupted Chell walking animation (and possibly other problems, didn't test further)