### PR TITLE
Correct game name, region, and save size in header

### DIFF
--- a/asm/rom_header.s
+++ b/asm/rom_header.s
@@ -14,10 +14,10 @@
 .word  0x00000000               /* Checksum 2 (OVERWRITTEN BY MAKEMASK)*/
 .word  0x00000000               /* Unknown */
 .word  0x00000000               /* Unknown */
-.ascii "                    "   /* Internal ROM name (Max 20 characters) */
-.word  0x01000000               /* Advanced_Homebrew_ROM_Header (controller config) */
-/* Game ID (EXAMPLE: NSME) Begins here */
-.word  0x0000004E                /* Cartridge Type (N)*/
-.ascii "ED"                     /* Cartridge ID (SM)*/
-.ascii " "			/* Region (E)*/
-.byte  0x30			/* Version */
+.ascii "Portal 64           "   /* Internal ROM name (Max 20 characters) */
+
+.word  0x01000000               /* Unused officially / Advanced homebrew ROM header controller config */
+.word  0x0000004E               /* Cartridge Type (N; cart)*/
+.ascii "ED"                     /* Cartridge ID (ED) / Advanced homebrew ROM header magic value */
+.byte  0x45                     /* Region (E; North America)*/
+.byte  0x32                     /* Version / Advanced homebrew ROM header misc. (region-free + 256K SRAM) */


### PR DESCRIPTION
* Add the game's name to the ROM header, so it shows up more nicely in emulators, flash carts, and cartridge readers
* Set the correct country value to match the comment (E = `0x45` = "North America/USA")
* Update the last advanced homebrew header byte to be more accurate
    * Bit 1 = region free
    * 3 in the upper nybble = 256K SRAM
    * The previous value of 4 in the upper nybble indicates 768K SRAM, which is incorrect (see https://n64brew.dev/wiki/ROM_Header#Advanced_Homebrew_ROM_Header)
* Also update comments around advanced homebrew ROM header, since I was confused at first and others might be too