### PR TITLE
Render HUD during intro fade when pausing

### DIFF
--- a/src/scene/scene.c
+++ b/src/scene/scene.c
@@ -326,11 +326,12 @@ void sceneRender(struct Scene* scene, struct RenderState* renderState, struct Gr
     gDPSetRenderMode(renderState->dl++, G_RM_OPA_SURF, G_RM_OPA_SURF2);
     gSPGeometryMode(renderState->dl++, G_ZBUFFER | G_LIGHTING | G_CULL_BOTH, G_SHADE);
 
+    if (gGameMenu.state == GameMenuStateResumeGame || scene->hud->fadeInTimer > 0.0f) {
+        hudRender(&scene->hud, &scene->player, renderState);
+    }
+
     if (gGameMenu.state != GameMenuStateResumeGame) {
         gameMenuRender(&gGameMenu, renderState, task);
-    }
-    else{
-        hudRender(&scene->hud, &scene->player, renderState);
     }
         
 

--- a/src/scene/scene.c
+++ b/src/scene/scene.c
@@ -326,7 +326,7 @@ void sceneRender(struct Scene* scene, struct RenderState* renderState, struct Gr
     gDPSetRenderMode(renderState->dl++, G_RM_OPA_SURF, G_RM_OPA_SURF2);
     gSPGeometryMode(renderState->dl++, G_ZBUFFER | G_LIGHTING | G_CULL_BOTH, G_SHADE);
 
-    if (gGameMenu.state == GameMenuStateResumeGame || scene->hud->fadeInTimer > 0.0f) {
+    if (gGameMenu.state == GameMenuStateResumeGame || scene->hud.fadeInTimer > 0.0f) {
         hudRender(&scene->hud, &scene->player, renderState);
     }
 


### PR DESCRIPTION
The HUD is responsible for filling the screen with black. Before this fix, when pausing during the intro the level would become visible. This used to work and broke in eb5668f4852d738781c469885deeb38c0df31f3b.

Before:
![portal_64-001](https://github.com/lambertjamesd/portal64/assets/9356790/0b60cd15-5947-4299-8b4c-26648a2ef518)

After:
![portal_64-000](https://github.com/lambertjamesd/portal64/assets/9356790/bc31afe7-fd10-41cc-97ff-1e69cf14f883)

This is a bit of a hack (checking HUD state in the scene). I was thinking about moving the intro fade logic into `scene.c` because of this, to make it cleaner. But then I saw that the HUD handles the death overlay as well (another screen fill effect), and so I thought it best to leave it and avoid a large change for this small issue.

Let me know if the hack is more trouble than it's worth for this very easy to miss situation. I do think the polish is nice though. I found the bug while trying to get in-game to test something else related to the pause menu and it felt jarring.