### PR TITLE
skelatool64: fix make clean

### DIFF
--- a/skelatool64/makefile
+++ b/skelatool64/makefile
@@ -34,6 +34,7 @@ skeletool64: $(OBJ_FILES) $(LUA_OBJ_FILES)
 clean:
 	rm -rf build/
 	rm -f skeletool64
+	rm -f CImg_*
 
 init:
 	

--- a/skelatool64/makefile
+++ b/skelatool64/makefile
@@ -32,7 +32,8 @@ skeletool64: $(OBJ_FILES) $(LUA_OBJ_FILES)
 	g++ -g -o skeletool64 $(OBJ_FILES) $(LUA_OBJ_FILES) $(LINKER_FLAGS)
 
 clean:
-	rm -r build/
+	rm -rf build/
+	rm -f skeletool64
 
 init:
 	


### PR DESCRIPTION
skelatool64/ `make clean` doesn't work cleanly:
```
cd skelatool64
make clean
```

Suggested fixes:

1) Use -f (force), so that skelatool64/build/ being empty isn't an error:
-> rm -rf build/

2) Also remove the skelatool64/skeletool64 binary:
-> rm -f skeletool64