### PR TITLE
Sort CODEFILES in Makefile 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
 build
+portal_pak_dir
+portal_pak_modified
 vpk
 skelatool64/build
 skelatool64/cimg

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ ASMFILES    =	$(shell find asm/ -type f -name '*.s')
 
 ASMOBJECTS  =	$(patsubst %.s, build/%.o, $(ASMFILES))
 
-CODEFILES = $(shell find src/ -type f -name '*.c')
+CODEFILES = $(shell find src/ -type f -name '*.c' | sort)
 
 ifeq ($(PORTAL64_WITH_GFX_VALIDATOR),1)
 LCDEFS += -DPORTAL64_WITH_GFX_VALIDATOR


### PR DESCRIPTION
Link order matters when generating `codesegment*.o`. The old sort order of `CODEFILES` was OS/file system dependent. On some systems, the order resulted in a working ROM. On other systems (like mine), the order resulted in a ROM that would hang on a black screen.

For example, on my Ubuntu VM the (working) result of `find src/ -type f -name '*.c'` is:
<details>
<summary>Command output</summary>
<blockquote>
src/audio/clips.c<br> 
src/audio/audio.c<br> 
src/audio/soundplayer.c<br> 
src/audio/audiomgr.c<br> 
src/audio/soundarray.c<br> 
src/savefile/savefile.c<br> 
src/savefile/serializer.c<br> 
src/savefile/checkpoint.c<br> 
src/savefile/scene_serialize.c<br> 
src/main.c<br> 
src/font/liberation_mono_images.c<br> 
src/font/dejavusans_images.c<br> 
src/font/liberation_mono.c<br> 
src/font/dejavusans.c<br> 
src/font/font.c<br> 
src/levels/cutscene_runner.c<br> 
src/levels/intro.c<br> 
src/levels/credits.c<br> 
src/levels/levels.c<br> 
src/levels/static_render.c<br> 
src/levels/level_definition.c<br> 
src/levels/material_state.c<br> 
src/controls/controller.c<br> 
src/controls/controller_actions.c<br> 
src/controls/rumble_pak.c<br> 
src/materials/point_light_rendered.c<br> 
src/materials/shadow_caster.c<br> 
src/materials/subject.c<br> 
src/materials/light.c<br> 
src/effects/portal_trail.c<br> 
src/effects/effects.c<br> 
src/effects/effect_definitions.c<br> 
src/effects/splash_particle_effect.c<br> 
src/scene/portal_surface_generator.c<br> 
src/scene/render_plan.c<br> 
src/scene/fizzler.c<br> 
src/scene/dynamic_render_list.c<br> 
src/scene/scene_animator.c<br> 
src/scene/ball_launcher.c<br> 
src/scene/camera.c<br> 
src/scene/point_light.c<br> 
src/scene/portal_render.c<br> 
src/scene/pedestal.c<br> 
src/scene/portal_surface_gfx.c<br> 
src/scene/shadow_map.c<br> 
src/scene/button.c<br> 
src/scene/security_camera.c<br> 
src/scene/dynamic_scene.c<br> 
src/scene/clock.c<br> 
src/scene/scene.c<br> 
src/scene/portal_gun.c<br> 
src/scene/ball.c<br> 
src/scene/elevator.c<br> 
src/scene/hud.c<br> 
src/scene/portal_surface.c<br> 
src/scene/trigger_listener.c<br> 
src/scene/signage.c<br> 
src/scene/shadow_renderer.c<br> 
src/scene/static_scene.c<br> 
src/scene/portal.c<br> 
src/scene/door.c<br> 
src/scene/switch.c<br> 
src/scene/box_dropper.c<br> 
src/scene/signals.c<br> 
src/scene/ball_catcher.c<br> 
src/math/boxs16.c<br> 
src/math/basis.c<br> 
src/math/mathf.c<br> 
src/math/rotated_box.c<br> 
src/math/vector2s16.c<br> 
src/math/vector2.c<br> 
src/math/vector3.c<br> 
src/math/matrix.c<br> 
src/math/box3d.c<br> 
src/math/plane.c<br> 
src/math/ray.c<br> 
src/math/box2d.c<br> 
src/math/transform.c<br> 
src/math/vector4.c<br> 
src/math/quaternion.c<br> 
src/physics/collision_object.c<br> 
src/physics/raycasting.c<br> 
src/physics/collision_quad.c<br> 
src/physics/world.c<br> 
src/physics/epa.c<br> 
src/physics/mesh_collider.c<br> 
src/physics/rigid_body.c<br> 
src/physics/collision_point.c<br> 
src/physics/collision.c<br> 
src/physics/collision_scene.c<br> 
src/physics/collision_box.c<br> 
src/physics/gjk.c<br> 
src/physics/collision_sphere.c<br> 
src/physics/collision_cylinder.c<br> 
src/physics/line.c<br> 
src/physics/contact_insertion.c<br> 
src/physics/point_constraint.c<br> 
src/physics/debug_renderer.c<br> 
src/physics/collision_capsule.c<br> 
src/physics/contact_solver.c<br> 
src/menu/savefile_list.c<br> 
src/menu/menu.c<br> 
src/menu/text_manipulation.c<br> 
src/menu/translations.c<br> 
src/menu/tabs.c<br> 
src/menu/options_menu.c<br> 
src/menu/controls.c<br> 
src/menu/save_game_menu.c<br> 
src/menu/joystick_options.c<br> 
src/menu/main_menu.c<br> 
src/menu/new_game_menu.c<br> 
src/menu/gameplay_options.c<br> 
src/menu/load_game.c<br> 
src/menu/game_menu.c<br> 
src/menu/audio_options.c<br> 
src/menu/video_options.c<br> 
src/menu/cheat_codes.c<br> 
src/menu/menu_builder.c<br> 
src/menu/landing_menu.c<br> 
src/util/assert.c<br> 
src/util/dynamic_asset_loader.c<br> 
src/util/dynamic_asset_data.c<br> 
src/util/dynamic_animated_asset_data.c<br> 
src/util/rom.c<br> 
src/util/profile.c<br> 
src/util/time.c<br> 
src/util/memory.c<br> 
src/util/linked_list.c<br> 
src/locales/locales.c<br> 
src/sk64/skelatool_animator.c<br> 
src/sk64/skelatool_armature.c<br> 
src/decor/decor_object_list.c<br> 
src/decor/decor_object.c<br> 
src/graphics/profile_task.c<br> 
src/graphics/debug_render.c<br> 
src/graphics/initgfx.c<br> 
src/graphics/renderstate.c<br> 
src/graphics/graphics.c<br> 
src/graphics/color.c<br> 
src/graphics/image.c<br> 
src/graphics/screen_clipper.c<br> 
src/graphics/render_scene.c<br> 
src/player/player_rumble_clips.c<br> 
src/player/player.c<br>
</blockquote>
</details>

On my host system, the (non-working) output is:
<details>
<summary>Command output</summary>
<blockquote>
src/controls/controller.c<br> 
src/controls/rumble_pak.c<br> 
src/controls/controller_actions.c<br> 
src/physics/contact_insertion.c<br> 
src/physics/world.c<br> 
src/physics/mesh_collider.c<br> 
src/physics/collision_box.c<br> 
src/physics/raycasting.c<br> 
src/physics/collision_object.c<br> 
src/physics/collision_scene.c<br> 
src/physics/collision_sphere.c<br> 
src/physics/line.c<br> 
src/physics/gjk.c<br> 
src/physics/rigid_body.c<br> 
src/physics/collision_cylinder.c<br> 
src/physics/collision_capsule.c<br> 
src/physics/collision.c<br> 
src/physics/epa.c<br> 
src/physics/point_constraint.c<br> 
src/physics/debug_renderer.c<br> 
src/physics/collision_point.c<br> 
src/physics/contact_solver.c<br> 
src/physics/collision_quad.c<br> 
src/levels/cutscene_runner.c<br> 
src/levels/intro.c<br> 
src/levels/credits.c<br> 
src/levels/material_state.c<br> 
src/levels/level_definition.c<br> 
src/levels/static_render.c<br> 
src/levels/levels.c<br> 
src/player/player.c<br> 
src/player/player_rumble_clips.c<br> 
src/audio/audio.c<br> 
src/audio/soundplayer.c<br> 
src/audio/clips.c<br> 
src/audio/soundarray.c<br> 
src/audio/audiomgr.c<br> 
src/math/box3d.c<br> 
src/math/basis.c<br> 
src/math/ray.c<br> 
src/math/vector2s16.c<br> 
src/math/quaternion.c<br> 
src/math/vector4.c<br> 
src/math/mathf.c<br> 
src/math/matrix.c<br> 
src/math/plane.c<br> 
src/math/rotated_box.c<br> 
src/math/transform.c<br> 
src/math/boxs16.c<br> 
src/math/vector3.c<br> 
src/math/box2d.c<br> 
src/math/vector2.c<br> 
src/materials/shadow_caster.c<br> 
src/materials/point_light_rendered.c<br> 
src/materials/light.c<br> 
src/materials/subject.c<br> 
src/effects/splash_particle_effect.c<br> 
src/effects/effects.c<br> 
src/effects/effect_definitions.c<br> 
src/effects/portal_trail.c<br> 
src/graphics/image.c<br> 
src/graphics/screen_clipper.c<br> 
src/graphics/color.c<br> 
src/graphics/graphics.c<br> 
src/graphics/renderstate.c<br> 
src/graphics/initgfx.c<br> 
src/graphics/render_scene.c<br> 
src/graphics/debug_render.c<br> 
src/graphics/profile_task.c<br> 
src/decor/decor_object_list.c<br> 
src/decor/decor_object.c<br> 
src/savefile/savefile.c<br> 
src/savefile/serializer.c<br> 
src/savefile/scene_serialize.c<br> 
src/savefile/checkpoint.c<br> 
src/util/dynamic_animated_asset_data.c<br> 
src/util/dynamic_asset_data.c<br> 
src/util/profile.c<br> 
src/util/time.c<br> 
src/util/linked_list.c<br> 
src/util/memory.c<br> 
src/util/assert.c<br> 
src/util/rom.c<br> 
src/util/dynamic_asset_loader.c<br> 
src/sk64/skelatool_armature.c<br> 
src/sk64/skelatool_animator.c<br> 
src/menu/load_game.c<br> 
src/menu/main_menu.c<br> 
src/menu/options_menu.c<br> 
src/menu/menu_builder.c<br> 
src/menu/gameplay_options.c<br> 
src/menu/new_game_menu.c<br> 
src/menu/save_game_menu.c<br> 
src/menu/controls.c<br> 
src/menu/joystick_options.c<br> 
src/menu/menu.c<br> 
src/menu/cheat_codes.c<br> 
src/menu/text_manipulation.c<br> 
src/menu/tabs.c<br> 
src/menu/audio_options.c<br> 
src/menu/game_menu.c<br> 
src/menu/landing_menu.c<br> 
src/menu/savefile_list.c<br> 
src/menu/video_options.c<br> 
src/menu/translations.c<br> 
src/font/dejavusans.c<br> 
src/font/liberation_mono.c<br> 
src/font/liberation_mono_images.c<br> 
src/font/dejavusans_images.c<br> 
src/font/font.c<br> 
src/main.c<br> 
src/locales/locales.c<br> 
src/scene/render_plan.c<br> 
src/scene/ball_launcher.c<br> 
src/scene/signals.c<br> 
src/scene/box_dropper.c<br> 
src/scene/switch.c<br> 
src/scene/hud.c<br> 
src/scene/scene_animator.c<br> 
src/scene/elevator.c<br> 
src/scene/trigger_listener.c<br> 
src/scene/shadow_renderer.c<br> 
src/scene/fizzler.c<br> 
src/scene/security_camera.c<br> 
src/scene/point_light.c<br> 
src/scene/static_scene.c<br> 
src/scene/ball.c<br> 
src/scene/portal_surface_generator.c<br> 
src/scene/camera.c<br> 
src/scene/portal_surface_gfx.c<br> 
src/scene/pedestal.c<br> 
src/scene/scene.c<br> 
src/scene/ball_catcher.c<br> 
src/scene/portal_surface.c<br> 
src/scene/dynamic_render_list.c<br> 
src/scene/dynamic_scene.c<br> 
src/scene/portal_gun.c<br> 
src/scene/clock.c<br> 
src/scene/signage.c<br> 
src/scene/portal_render.c<br> 
src/scene/portal.c<br> 
src/scene/door.c<br> 
src/scene/shadow_map.c<br> 
src/scene/button.c<br>
</blockquote>
</details>

This is why I could build in an Ubuntu VM, but not when using shared folders to keep my portal64 clone outside of the VM, or when using Docker. My host's file system iterated through the files in a different order.

Sorting the file paths alphabetically results in a different (but working) order to ensure consistent linking across environments:
<details>
<summary>Command output</summary>
<blockquote>
src/audio/audio.c<br> 
src/audio/audiomgr.c<br> 
src/audio/clips.c<br> 
src/audio/soundarray.c<br> 
src/audio/soundplayer.c<br> 
src/controls/controller_actions.c<br> 
src/controls/controller.c<br> 
src/controls/rumble_pak.c<br> 
src/decor/decor_object.c<br> 
src/decor/decor_object_list.c<br> 
src/effects/effect_definitions.c<br> 
src/effects/effects.c<br> 
src/effects/portal_trail.c<br> 
src/effects/splash_particle_effect.c<br> 
src/font/dejavusans.c<br> 
src/font/dejavusans_images.c<br> 
src/font/font.c<br> 
src/font/liberation_mono.c<br> 
src/font/liberation_mono_images.c<br> 
src/graphics/color.c<br> 
src/graphics/debug_render.c<br> 
src/graphics/graphics.c<br> 
src/graphics/image.c<br> 
src/graphics/initgfx.c<br> 
src/graphics/profile_task.c<br> 
src/graphics/render_scene.c<br> 
src/graphics/renderstate.c<br> 
src/graphics/screen_clipper.c<br> 
src/levels/credits.c<br> 
src/levels/cutscene_runner.c<br> 
src/levels/intro.c<br> 
src/levels/level_definition.c<br> 
src/levels/levels.c<br> 
src/levels/material_state.c<br> 
src/levels/static_render.c<br> 
src/locales/locales.c<br> 
src/main.c<br> 
src/materials/light.c<br> 
src/materials/point_light_rendered.c<br> 
src/materials/shadow_caster.c<br> 
src/materials/subject.c<br> 
src/math/basis.c<br> 
src/math/box2d.c<br> 
src/math/box3d.c<br> 
src/math/boxs16.c<br> 
src/math/mathf.c<br> 
src/math/matrix.c<br> 
src/math/plane.c<br> 
src/math/quaternion.c<br> 
src/math/ray.c<br> 
src/math/rotated_box.c<br> 
src/math/transform.c<br> 
src/math/vector2.c<br> 
src/math/vector2s16.c<br> 
src/math/vector3.c<br> 
src/math/vector4.c<br> 
src/menu/audio_options.c<br> 
src/menu/cheat_codes.c<br> 
src/menu/controls.c<br> 
src/menu/game_menu.c<br> 
src/menu/gameplay_options.c<br> 
src/menu/joystick_options.c<br> 
src/menu/landing_menu.c<br> 
src/menu/load_game.c<br> 
src/menu/main_menu.c<br> 
src/menu/menu_builder.c<br> 
src/menu/menu.c<br> 
src/menu/new_game_menu.c<br> 
src/menu/options_menu.c<br> 
src/menu/savefile_list.c<br> 
src/menu/save_game_menu.c<br> 
src/menu/tabs.c<br> 
src/menu/text_manipulation.c<br> 
src/menu/translations.c<br> 
src/menu/video_options.c<br> 
src/physics/collision_box.c<br> 
src/physics/collision.c<br> 
src/physics/collision_capsule.c<br> 
src/physics/collision_cylinder.c<br> 
src/physics/collision_object.c<br> 
src/physics/collision_point.c<br> 
src/physics/collision_quad.c<br> 
src/physics/collision_scene.c<br> 
src/physics/collision_sphere.c<br> 
src/physics/contact_insertion.c<br> 
src/physics/contact_solver.c<br> 
src/physics/debug_renderer.c<br> 
src/physics/epa.c<br> 
src/physics/gjk.c<br> 
src/physics/line.c<br> 
src/physics/mesh_collider.c<br> 
src/physics/point_constraint.c<br> 
src/physics/raycasting.c<br> 
src/physics/rigid_body.c<br> 
src/physics/world.c<br> 
src/player/player.c<br> 
src/player/player_rumble_clips.c<br> 
src/savefile/checkpoint.c<br> 
src/savefile/savefile.c<br> 
src/savefile/scene_serialize.c<br> 
src/savefile/serializer.c<br> 
src/scene/ball.c<br> 
src/scene/ball_catcher.c<br> 
src/scene/ball_launcher.c<br> 
src/scene/box_dropper.c<br> 
src/scene/button.c<br> 
src/scene/camera.c<br> 
src/scene/clock.c<br> 
src/scene/door.c<br> 
src/scene/dynamic_render_list.c<br> 
src/scene/dynamic_scene.c<br> 
src/scene/elevator.c<br> 
src/scene/fizzler.c<br> 
src/scene/hud.c<br> 
src/scene/pedestal.c<br> 
src/scene/point_light.c<br> 
src/scene/portal.c<br> 
src/scene/portal_gun.c<br> 
src/scene/portal_render.c<br> 
src/scene/portal_surface.c<br> 
src/scene/portal_surface_generator.c<br> 
src/scene/portal_surface_gfx.c<br> 
src/scene/render_plan.c<br> 
src/scene/scene_animator.c<br> 
src/scene/scene.c<br> 
src/scene/security_camera.c<br> 
src/scene/shadow_map.c<br> 
src/scene/shadow_renderer.c<br> 
src/scene/signage.c<br> 
src/scene/signals.c<br> 
src/scene/static_scene.c<br> 
src/scene/switch.c<br> 
src/scene/trigger_listener.c<br> 
src/sk64/skelatool_animator.c<br> 
src/sk64/skelatool_armature.c<br> 
src/util/assert.c<br> 
src/util/dynamic_animated_asset_data.c<br> 
src/util/dynamic_asset_data.c<br> 
src/util/dynamic_asset_loader.c<br> 
src/util/linked_list.c<br> 
src/util/memory.c<br> 
src/util/profile.c<br> 
src/util/rom.c<br> 
src/util/time.c<br> 
</blockquote>
</details>

This should fix issue #555 and possibly #409. PR #561 was intended to fix this problem but is unnecessary.

A more resilient fix is to explicitly list all files in the correct order in the Makefile (as more files are added in the future, the sorted order could become incorrect). I didn't go that way to avoid bloating the Makefile - it seems the current find-based approach was used to make adding files easier. @lambertjamesd, let me know if you're fine with the "explicit list" approach instead since it is more future-proof. If you are, I will make that change.