### PR TITLE
attempt to make "clean" in Makefile.docker actually clean skelatool64

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -15,7 +15,7 @@ clean:
 	sudo rm -rf portal_pak_dir
 	sudo rm -rf portal_pak_modified
 	sudo rm -rf assets/locales
-	sudo @$(MAKE) -C skelatool64 clean
+	sudo $(MAKE) -C skelatool64 clean
 	
 english_audio:
 	docker run --rm -v $$PWD:/usr/src/app -e PORTAL64_WITH_DEBUGGER -e PORTAL64_WITH_GFX_VALIDATOR -it portal64 make english_audio


### PR DESCRIPTION
After this change, `make -f Makefile.docker clean` no longer shows this error:

```
...
sudo @make -C skelatool64 clean
sudo: @make: command not found
make: *** [Makefile.docker:18: clean] Error 1
```

I did get lots of ugly new make spew though (the root cause should probably be fixed elsewhere later), but at least skelatool64 now cleaned properly, I think.