### PR TITLE
Readme reformat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ VTF2PNG:=vtf2png
 SFZ2N64:=sfz2n64
 
 $(SKELATOOL64):
-	chmod +x skelatool64/setup_dependencies.sh
 	skelatool64/setup_dependencies.sh
 
 
@@ -559,7 +558,6 @@ $(BASE_TARGET_NAME).z64: $(CODESEGMENT)_no_debug.o $(OBJECTS) $(DATA_OBJECTS) $(
 	$(LD) -L. -T $(CP_LD_SCRIPT)_no_debug.ld -Map $(BASE_TARGET_NAME)_no_debug.map -o $(BASE_TARGET_NAME).elf
 	$(OBJCOPY) --pad-to=0x100000 --gap-fill=0xFF $(BASE_TARGET_NAME).elf $(BASE_TARGET_NAME).z64 -O binary
 	makemask $(BASE_TARGET_NAME).z64
-	chmod +x tools/romfix64.sh
 	sh tools/romfix64.sh $(BASE_TARGET_NAME).z64
 
 # with debugger
@@ -579,7 +577,6 @@ $(BASE_TARGET_NAME)_debug.z64: $(CODESEGMENT)_debug.o $(OBJECTS) $(DATA_OBJECTS)
 	$(LD) -L. -T $(CP_LD_SCRIPT)_debug.ld -Map $(BASE_TARGET_NAME)_debug.map -o $(BASE_TARGET_NAME)_debug.elf
 	$(OBJCOPY) --pad-to=0x100000 --gap-fill=0xFF $(BASE_TARGET_NAME)_debug.elf $(BASE_TARGET_NAME)_debug.z64 -O binary
 	makemask $(BASE_TARGET_NAME)_debug.z64
-	chmod +x tools/romfix64.sh
 	sh tools/romfix64.sh $(BASE_TARGET_NAME).z64
 
 clean:
@@ -608,11 +605,5 @@ clean-assets:
 	rm -f $(BASE_TARGET_NAME).z64
 	rm -f $(BASE_TARGET_NAME)_debug.z64
 
-fix:
-	wine tools/romfix64.exe $(BASE_TARGET_NAME).z64
-
-fix-nowine:
-	chmod +x tools/romfix64.sh
-	sh tools/romfix64.sh $(BASE_TARGET_NAME).z64
 
 .SECONDARY:

--- a/README.md
+++ b/README.md
@@ -55,9 +55,12 @@ sudo chmod +x setup.sh
 ./setup.sh
 
 ```
-You can also follow the manual setup instructions [here](https://github.com/lambertjamesd/portal64])
+Alternatively, you could just follow the manual setup instructions [here](documentation/manual_setup.md]).
 
-You then need to add the following files from where Portal is installed to the folder `vpk/` OR create a symbolic link to the `Portal` folder there (see [vpk/add_vpk_here.md](./vpk/add_vpk_here.md) for more details!).
+
+
+After setup, You need to add the following files from where Portal is installed to the folder `vpk/` OR create a symbolic link to the `Portal` folder there (see [vpk/add_vpk_here.md](./vpk/add_vpk_here.md) for more details!).
+
 You can add multiple languages if desired.
 
 ```

--- a/README.md
+++ b/README.md
@@ -36,38 +36,6 @@ Updates are constantly being made to the game, so we recommend checking out the 
 
 ## How to build
 
-First, you will need to setup [Modern SDK](https://crashoveride95.github.io/n64hbrew/modernsdk/startoff.html).
-
-After installing modern sdk you will want to also install
-
-```sh
-sudo apt install libnustd
-```
-
-Next, you will need to install the latest version of Blender 3.6 LTS (please don't use e.g. 4.x, only 3.6.x will work correctly). Then set the environment variable `BLENDER_3_6` to be the absolute path where the Blender 3.6 executable is located on your system.
-
-```sh
-sudo snap install blender --channel=3.6lts/stable --classic
-```
-
-e.g. add this to your ~/.bashrc if you used snap (or you can use `which blender` to find the path of Blender 3.6)
-
-```bash
-export BLENDER_3_6="/snap/bin/blender"
-```
-
-<br />
-
-You will need to install Python `vpk`:
-
-```sh
-sudo apt install pipx
-pipx ensurepath
-pipx install vpk
-```
-
-<br />
-
 Clone the Portal64 repo or download the zip.
 
 ```sh
@@ -75,37 +43,19 @@ sudo apt install git
 git clone https://github.com/lambertjamesd/portal64.git
 cd portal64
 ```
-Setup and install dependencies for `skelatool64`
+Setup and install dependencies. 
+The following commands allow the scripts to run on the system, then it runs the setup.
 
+As always it in good practice look over scripts from the internet before running them on your system. 
 ```sh
-echo "deb [trusted=yes] https://lambertjamesd.github.io/apt/ ./" \
-    | sudo tee /etc/apt/sources.list.d/lambertjamesd.list
-sudo apt update
-sudo apt install vtf2png sfz2n64 mpg123 sox imagemagick unzip
-``
-```
-Install ffmpeg 4.3.1
-```
-sudo snap install ffmpeg  # version 4.3.1
+
+sudo chmod +x skelatool64/setup_dependencies.sh
+sudo chmod +x tools/romfix64.sh
+sudo chmod +x setup.sh
+./setup.sh
 
 ```
-
-<br />
-
-Install lua5.4 (You may need to remove other installed versions first, skelatool64 needs to be built with luac 5.4!)
-
-```sh
-sudo apt install lua5.4 liblua5.4-dev liblua5.4-0
-```
-<br />
-
-You will need to install nodejs. You can use apt for this
-
-```sh
-sudo apt install nodejs
-```
-
-<br />
+You can also follow the manual setup instructions [here](https://github.com/lambertjamesd/portal64])
 
 You then need to add the following files from where Portal is installed to the folder `vpk/` OR create a symbolic link to the `Portal` folder there (see [vpk/add_vpk_here.md](./vpk/add_vpk_here.md) for more details!).
 You can add multiple languages if desired.

--- a/README.md
+++ b/README.md
@@ -40,9 +40,13 @@ Clone the Portal64 repo or download the zip.
 
 ```sh
 sudo apt install git
+```
+
+```sh
 git clone https://github.com/lambertjamesd/portal64.git
 cd portal64
 ```
+
 Setup and install dependencies. 
 The following commands allow the scripts to run on the system, then it runs the setup.
 

--- a/README.md
+++ b/README.md
@@ -39,10 +39,7 @@ Updates are constantly being made to the game, so we recommend checking out the 
 Clone the Portal64 repo or download the zip.
 
 ```sh
-sudo apt install git
-```
-
-```sh
+sudo apt install git -y
 git clone https://github.com/lambertjamesd/portal64.git
 cd portal64
 ```

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ sudo chmod +x setup.sh
 ./setup.sh
 
 ```
-Alternatively, you could just follow the manual setup instructions [here](documentation/manual_setup.md]).
+Alternatively, you could just follow the manual setup instructions [here](./documentation/manual_setup.md).
 
 
 

--- a/README.md
+++ b/README.md
@@ -112,12 +112,15 @@ make clean
 # Build (default build with english audio)
 make
 
+```
 You can also prepare to build the ROM with additional audio languages, like this (multiple commands per build possible):
-
 ```
 make french_audio
+
 make german_audio
+
 make russian_audio
+
 make spanish_audio
 ```
 You still have run `make` after this.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ cd portal64
 Setup and install dependencies. 
 The following commands allow the scripts to run on the system, then it runs the setup.
 
-As always it in good practice look over scripts from the internet before running them on your system. 
+As always it is good practice look over scripts from the internet before running them on your system. 
 ```sh
 
 sudo chmod +x skelatool64/setup_dependencies.sh

--- a/documentation/manual_setup.md
+++ b/documentation/manual_setup.md
@@ -1,0 +1,70 @@
+## How to build
+
+First, you will need to setup [Modern SDK](https://crashoveride95.github.io/n64hbrew/modernsdk/startoff.html).
+
+After installing modern sdk you will want to also install
+
+```sh
+sudo apt install libnustd
+```
+
+Next, you will need to install the latest version of Blender 3.6 LTS (please don't use e.g. 4.x, only 3.6.x will work correctly). Then set the environment variable `BLENDER_3_6` to be the absolute path where the Blender 3.6 executable is located on your system.
+
+```sh
+sudo snap install blender --channel=3.6lts/stable --classic
+```
+
+e.g. add this to your ~/.bashrc if you used snap (or you can use `which blender` to find the path of Blender 3.6)
+
+```bash
+export BLENDER_3_6="/snap/bin/blender"
+```
+
+<br />
+
+You will need to install Python `vpk`:
+
+```sh
+sudo apt install pipx
+pipx ensurepath
+pipx install vpk
+```
+
+<br />
+
+Clone the Portal64 repo or download the zip.
+
+```sh
+sudo apt install git
+git clone https://github.com/lambertjamesd/portal64.git
+cd portal64
+```
+Setup and install dependencies for `skelatool64`
+
+```sh
+echo "deb [trusted=yes] https://lambertjamesd.github.io/apt/ ./" \
+    | sudo tee /etc/apt/sources.list.d/lambertjamesd.list
+sudo apt update
+sudo apt install vtf2png sfz2n64 mpg123 sox imagemagick unzip
+``
+```
+Install ffmpeg 4.3.1
+```
+sudo snap install ffmpeg  # version 4.3.1
+
+```
+
+<br />
+
+Install lua5.4 (You may need to remove other installed versions first, skelatool64 needs to be built with luac 5.4!)
+
+```sh
+sudo apt install lua5.4 liblua5.4-dev liblua5.4-0
+```
+<br />
+
+You will need to install nodejs. You can use apt for this
+
+```sh
+sudo apt install nodejs
+```

--- a/setup.sh
+++ b/setup.sh
@@ -5,6 +5,7 @@ echo "deb [trusted=yes] https://crashoveride95.github.io/apt/ ./" | sudo tee /et
 echo "deb [trusted=yes] https://lambertjamesd.github.io/apt/ ./" | sudo tee /etc/apt/sources.list.d/lambertjamesd.list
 
 # Update system package lists
+sudo dpkg --add-architecture i386
 sudo apt update
 
 # Install various packages

--- a/setup.sh
+++ b/setup.sh
@@ -9,12 +9,10 @@ sudo dpkg --add-architecture i386
 sudo apt update
 
 # Install various packages
-sudo apt install binutils-mips-n64 gcc-mips-n64 git imagemagick liblua5.4-0 liblua5.4-dev libnustd lua5.4 makemask mpg123 newlib-mips-n64 nodejs n64sdk root-compatibility-environment sfz2n64 sox unzip vtf2png -y
+sudo apt install binutils-mips-n64 gcc-mips-n64 git imagemagick liblua5.4-0 liblua5.4-dev libnustd lua5.4 make makemask mpg123 newlib-mips-n64 nodejs n64sdk root-compatibility-environment sfz2n64 sox unzip vtf2png -y
 
-# Install pipx packages
-sudo apt install pipx -y
-pipx ensurepath --force
-pipx install vpk
+# Ubuntu WSL  needs these for some reason.
+sudo apt-get update && sudo apt-get install libnustd libxfixes3 libxi6 libxkbcommon0 libxxf86vm1 libgl1-mesa-glx -y
 
 # Install Blender and FFmpeg  specific versions via snap
 sudo snap install blender --channel=3.6lts/stable --classic
@@ -26,11 +24,17 @@ echo 'export BLENDER_3_6=/snap/bin/blender' >> ~/.bashrc
 echo 'export PATH=$PATH:/opt/crashsdk/bin' >> ~/.bashrc
 echo 'export ROOT=/etc/n64' >> ~/.bashrc
 
+# Install pipx packages
+sudo apt install pipx -y
+pipx ensurepath --force
+pipx install vpk
+
 # Source the updated .bashrc to apply changes in the current terminal
 source ~/.bashrc
 
 echo "Setup is almost complete. Add the files from the Portal folder to portal64/vpk"
+
 read -p "When complete, press Enter to finish setup."
 
 # Displaying 'Setup complete' message after user input
-echo "Setup complete."
+echo "Setup complete. Please restart the terminal if paths are not updated."

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Add repositories to system sources
+echo "deb [trusted=yes] https://crashoveride95.github.io/apt/ ./" | sudo tee /etc/apt/sources.list.d/n64sdk.list
+echo "deb [trusted=yes] https://lambertjamesd.github.io/apt/ ./" | sudo tee /etc/apt/sources.list.d/lambertjamesd.list
+
+# Update system package lists
+sudo apt update
+
+# Install git and clone a repository
+sudo apt install git -y
+git clone https://github.com/lambertjamesd/portal64.git
+cd portal64
+
+# Install various packages
+sudo apt install binutils-mips-n64 gcc-mips-n64 git imagemagick liblua5.4-0 liblua5.4-dev libnustd lua5.4 makemask mpg123 newlib-mips-n64 nodejs n64sdk root-compatibility-environment sfz2n64 sox unzip vtf2png -y
+
+# Install pipx packages
+sudo apt install pipx -y
+pipx ensurepath --force
+pipx install vpk
+
+# Install Blender and FFmpeg  specific versions via snap
+sudo snap install blender --channel=3.6lts/stable --classic
+sudo snap install ffmpeg
+
+# Append environment variables to .bashrc
+echo 'export N64_LIBGCCDIR=/opt/crashsdk/lib/gcc/mips64-elf/12.2.0' >> ~/.bashrc
+echo 'export BLENDER_3_6=/snap/bin/blender' >> ~/.bashrc
+echo 'export PATH=$PATH:/opt/crashsdk/bin' >> ~/.bashrc
+echo 'export ROOT=/etc/n64' >> ~/.bashrc
+
+# Source the updated .bashrc to apply changes in the current terminal
+source ~/.bashrc
+
+echo "Setup is almost complete. Add the files from the Portal folder to portal64/vpk"
+read -p "When complete, press Enter to finish setup."
+
+# Displaying 'Setup complete' message after user input
+echo "Setup complete."

--- a/setup.sh
+++ b/setup.sh
@@ -7,11 +7,6 @@ echo "deb [trusted=yes] https://lambertjamesd.github.io/apt/ ./" | sudo tee /etc
 # Update system package lists
 sudo apt update
 
-# Install git and clone a repository
-sudo apt install git -y
-git clone https://github.com/lambertjamesd/portal64.git
-cd portal64
-
 # Install various packages
 sudo apt install binutils-mips-n64 gcc-mips-n64 git imagemagick liblua5.4-0 liblua5.4-dev libnustd lua5.4 makemask mpg123 newlib-mips-n64 nodejs n64sdk root-compatibility-environment sfz2n64 sox unzip vtf2png -y
 


### PR DESCRIPTION
To attempt to close some issues. Restructure the ReadMe #545 and various other build issues.

I made a setup.sh that installs the dependencies, so that we can rule out user error more easily when debuging builds.
I also think that this makes the Readme cleaner. 

This PR adds a script to install the build dependencies.
It moves the manual setup to the documentation folder and 
add a link to it from the Readme.
I've tested the script on WSL Ubuntu 22.04.3 LTS, regular  Ubuntu 22.04.3 LTS 
and  regular Ubuntu 23.1 and all made a working ROM.