### PR TITLE
Introduce Portal UI look from Switch version

### DIFF
--- a/assets/materials/ui.skm.yaml
+++ b/assets/materials/ui.skm.yaml
@@ -209,3 +209,14 @@ materials:
     gDPSetTextureFilter: G_TF_BILERP
     gDPSetTextureLUT: G_TT_NONE
     gDPSetTexturePersp: G_TP_NONE
+
+  orange_transparent_overlay:
+    gDPSetCombineMode: 
+      color: ["0", "0", "0", ENVIRONMENT]
+      alpha: ["0", "0", "0", ENVIRONMENT]
+    gDPSetRenderMode: G_RM_XLU_SURF
+    gDPSetEnvColor:
+      r: 255  
+      g: 156
+      b: 0
+      a: 142

--- a/src/menu/landing_menu.c
+++ b/src/menu/landing_menu.c
@@ -157,19 +157,17 @@ void landingMenuRender(struct LandingMenu* landingMenu, struct RenderState* rend
         }
     }
 
+    gSPDisplayList(renderState->dl++, ui_material_list[ORANGE_TRANSPARENT_OVERLAY_INDEX]);
+    gDPFillRectangle(renderState->dl++,
+        landingMenu->optionText[landingMenu->selectedItem]->x - paddingDepthX,
+        landingMenu->optionText[landingMenu->selectedItem]->y - paddingDepthY,
+        landingMenu->optionText[landingMenu->selectedItem]->x + maxTextWidth + paddingDepthX,
+        landingMenu->optionText[landingMenu->selectedItem]->y + getCurrentStrideValue(landingMenu) - paddingDepthY);
+    gSPDisplayList(renderState->dl++, ui_material_revert_list[ORANGE_TRANSPARENT_OVERLAY_INDEX]);
+
     struct PrerenderedTextBatch* batch = prerenderedBatchStart();
     for (int i = 0; i < landingMenu->optionCount; ++i) {
         prerenderedBatchAdd(batch, landingMenu->optionText[i], &gColorWhite);
-
-		if (landingMenu->selectedItem == i ){
-			gSPDisplayList(renderState->dl++, ui_material_list[ORANGE_TRANSPARENT_OVERLAY_INDEX]);
-			gDPFillRectangle(renderState->dl++,
-                landingMenu->optionText[i]->x - paddingDepthX,
-                landingMenu->optionText[i]->y - paddingDepthY,
-                landingMenu->optionText[i]->x + maxTextWidth + paddingDepthX,
-                landingMenu->optionText[i]->y + getCurrentStrideValue(landingMenu) - paddingDepthY);
-		    gSPDisplayList(renderState->dl++, ui_material_revert_list[ORANGE_TRANSPARENT_OVERLAY_INDEX]);
-		}
     }
     renderState->dl = prerenderedBatchFinish(batch, gDejaVuSansImages, renderState->dl);
     gSPDisplayList(renderState->dl++, ui_material_revert_list[DEJAVU_SANS_0_INDEX]);

--- a/src/menu/landing_menu.c
+++ b/src/menu/landing_menu.c
@@ -146,12 +146,12 @@ void landingMenuRender(struct LandingMenu* landingMenu, struct RenderState* rend
 	
 	int paddingDepthY = 2;
 	int paddingDepthX = 4;
-	int highlightWidth = 120;
+	int highlightWidth = 160;
 	int landingMenuTextY = LANDING_MENU_TEXT_START_Y;
     int stride = getCurrentStrideValue(landingMenu);
 	if (landingMenu->optionCount > PACKED_MENU_THRESHOLD){
 		paddingDepthY = 0;
-		highlightWidth = 140;
+		highlightWidth = 185;
 	}
 
     struct PrerenderedTextBatch* batch = prerenderedBatchStart();

--- a/src/menu/landing_menu.c
+++ b/src/menu/landing_menu.c
@@ -65,16 +65,16 @@ void landingMenuInitText(struct LandingMenu* landingMenu) {
     int stride = getCurrentStrideValue(landingMenu);
 
     for (int i = 0; i < landingMenu->optionCount; ++i) {
-        landingMenu->optionText[i] = menuBuildPrerenderedText(&gDejaVuSansFont, 
-            translationsGet(landingMenu->options[i].messageId), 
-            LANDING_MENU_TEXT_START_X, 
-            y, 
+        landingMenu->optionText[i] = menuBuildPrerenderedText(&gDejaVuSansFont,
+            translationsGet(landingMenu->options[i].messageId),
+            LANDING_MENU_TEXT_START_X,
+            y,
             SCREEN_WD);
         y += stride;
     }
 }
 
-void landingMenuInit(struct LandingMenu* landingMenu, struct LandingMenuOption* options, int optionCount, int darkenBackground) {    
+void landingMenuInit(struct LandingMenu* landingMenu, struct LandingMenuOption* options, int optionCount, int darkenBackground) {
     landingMenu->optionText = malloc(sizeof(struct PrerenderedText*) * optionCount);
     landingMenu->options = options;
     landingMenu->selectedItem = 0;
@@ -96,7 +96,7 @@ struct LandingMenuOption* landingMenuUpdate(struct LandingMenu* landingMenu) {
     if (dir & ControllerDirectionUp) {
         if (landingMenu->selectedItem > 0) {
             --landingMenu->selectedItem;
-        } else { 
+        } else {
             landingMenu->selectedItem = landingMenu->optionCount - 1;
         }
         soundPlayerPlay(SOUNDS_BUTTONROLLOVER, 1.0f, 0.5f, NULL, NULL, SoundTypeAll);
@@ -133,7 +133,7 @@ struct LandingMenuOption* landingMenuUpdate(struct LandingMenu* landingMenu) {
 
 void landingMenuRender(struct LandingMenu* landingMenu, struct RenderState* renderState, struct GraphicsTask* task) {
     gSPDisplayList(renderState->dl++, ui_material_list[DEFAULT_UI_INDEX]);
-	
+
     if (landingMenu->darkenBackground) {
         gSPDisplayList(renderState->dl++, ui_material_list[SOLID_TRANSPARENT_OVERLAY_INDEX]);
         gDPFillRectangle(renderState->dl++, 0, 0, SCREEN_WD, SCREEN_HT);
@@ -143,12 +143,10 @@ void landingMenuRender(struct LandingMenu* landingMenu, struct RenderState* rend
     gSPDisplayList(renderState->dl++, ui_material_list[PORTAL_LOGO_INDEX]);
     gSPDisplayList(renderState->dl++, portal_logo_gfx);
     gSPDisplayList(renderState->dl++, ui_material_revert_list[PORTAL_LOGO_INDEX]);
-	
+
 	int paddingDepthY = 2;
 	int paddingDepthX = 4;
 	int highlightWidth = 160;
-	int landingMenuTextY = LANDING_MENU_TEXT_START_Y;
-    int stride = getCurrentStrideValue(landingMenu);
 	if (landingMenu->optionCount > PACKED_MENU_THRESHOLD){
 		paddingDepthY = 0;
 		highlightWidth = 185;
@@ -157,18 +155,17 @@ void landingMenuRender(struct LandingMenu* landingMenu, struct RenderState* rend
     struct PrerenderedTextBatch* batch = prerenderedBatchStart();
     for (int i = 0; i < landingMenu->optionCount; ++i) {
         prerenderedBatchAdd(batch, landingMenu->optionText[i], &gColorWhite);
-		
+
 		if (landingMenu->selectedItem == i ){
 			gSPDisplayList(renderState->dl++, ui_material_list[ORANGE_TRANSPARENT_OVERLAY_INDEX]);
-			gDPFillRectangle(renderState->dl++, 
-                LANDING_MENU_TEXT_START_X - paddingDepthX, 
-                landingMenuTextY - paddingDepthY,
-                highlightWidth + paddingDepthX, 
-                landingMenuTextY + stride - paddingDepthY);
+			gDPFillRectangle(renderState->dl++,
+                landingMenu->optionText[i]->x - paddingDepthX,
+                landingMenu->optionText[i]->y - paddingDepthY,
+                highlightWidth + paddingDepthX,
+                landingMenu->optionText[i]->y + getCurrentStrideValue(landingMenu) - paddingDepthY);
 		    gSPDisplayList(renderState->dl++, ui_material_revert_list[ORANGE_TRANSPARENT_OVERLAY_INDEX]);
 		}
-		landingMenuTextY += stride;
-    }		
+    }
     renderState->dl = prerenderedBatchFinish(batch, gDejaVuSansImages, renderState->dl);
     gSPDisplayList(renderState->dl++, ui_material_revert_list[DEJAVU_SANS_0_INDEX]);
 }

--- a/src/menu/landing_menu.c
+++ b/src/menu/landing_menu.c
@@ -23,6 +23,7 @@
 #define LANDING_MENU_TEXT_START_Y 132
 #define STRIDE_OPTION_1 12
 #define STRIDE_OPTION_2 16
+#define PACKED_MENU_THRESHOLD 4
 
 Gfx portal_logo_gfx[] = {
     gsSPTextureRectangle(
@@ -61,11 +62,14 @@ Gfx portal_logo_gfx[] = {
 
 void landingMenuInitText(struct LandingMenu* landingMenu) {
     int y = LANDING_MENU_TEXT_START_Y;
-
-    int stride = landingMenu->optionCount > 4 ? STRIDE_OPTION_1 : STRIDE_OPTION_2;
+    int stride = getCurrentStrideValue(landingMenu);
 
     for (int i = 0; i < landingMenu->optionCount; ++i) {
-        landingMenu->optionText[i] = menuBuildPrerenderedText(&gDejaVuSansFont, translationsGet(landingMenu->options[i].messageId), LANDING_MENU_TEXT_START_X, y, SCREEN_WD);
+        landingMenu->optionText[i] = menuBuildPrerenderedText(&gDejaVuSansFont, 
+            translationsGet(landingMenu->options[i].messageId), 
+            LANDING_MENU_TEXT_START_X, 
+            y, 
+            SCREEN_WD);
         y += stride;
     }
 }
@@ -143,9 +147,9 @@ void landingMenuRender(struct LandingMenu* landingMenu, struct RenderState* rend
 	int paddingDepthY = 2;
 	int paddingDepthX = 4;
 	int highlightWidth = 120;
-	int stride = landingMenu->optionCount > 4 ? STRIDE_OPTION_1 : STRIDE_OPTION_2;
 	int landingMenuTextY = LANDING_MENU_TEXT_START_Y;
-	if (landingMenu->optionCount > 4){
+    int stride = getCurrentStrideValue(landingMenu);
+	if (landingMenu->optionCount > PACKED_MENU_THRESHOLD){
 		paddingDepthY = 0;
 		highlightWidth = 140;
 	}
@@ -157,16 +161,19 @@ void landingMenuRender(struct LandingMenu* landingMenu, struct RenderState* rend
 		if (landingMenu->selectedItem == i ){
 			gSPDisplayList(renderState->dl++, ui_material_list[ORANGE_TRANSPARENT_OVERLAY_INDEX]);
 			gDPFillRectangle(renderState->dl++, 
-			LANDING_MENU_TEXT_START_X - paddingDepthX, 
-			landingMenuTextY - paddingDepthY,
-			highlightWidth + paddingDepthX, 
-			landingMenuTextY + stride - paddingDepthY);
-			
-		gSPDisplayList(renderState->dl++, ui_material_revert_list[SOLID_ENV_INDEX]);
+                LANDING_MENU_TEXT_START_X - paddingDepthX, 
+                landingMenuTextY - paddingDepthY,
+                highlightWidth + paddingDepthX, 
+                landingMenuTextY + stride - paddingDepthY);
+		    gSPDisplayList(renderState->dl++, ui_material_revert_list[ORANGE_TRANSPARENT_OVERLAY_INDEX]);
 		}
 		landingMenuTextY += stride;
-    }
-				
+    }		
     renderState->dl = prerenderedBatchFinish(batch, gDejaVuSansImages, renderState->dl);
     gSPDisplayList(renderState->dl++, ui_material_revert_list[DEJAVU_SANS_0_INDEX]);
+}
+
+int getCurrentStrideValue(struct LandingMenu* landingMenu)
+{
+    return (landingMenu->optionCount > PACKED_MENU_THRESHOLD ? STRIDE_OPTION_1 : STRIDE_OPTION_2);
 }

--- a/src/menu/landing_menu.c
+++ b/src/menu/landing_menu.c
@@ -146,11 +146,16 @@ void landingMenuRender(struct LandingMenu* landingMenu, struct RenderState* rend
 
 	int paddingDepthY = 2;
 	int paddingDepthX = 4;
-	int highlightWidth = 160;
 	if (landingMenu->optionCount > PACKED_MENU_THRESHOLD){
 		paddingDepthY = 0;
-		highlightWidth = 185;
 	}
+
+    int maxTextWidth = 0;
+    for (int i = 0; i < landingMenu->optionCount; ++i) {
+        if (landingMenu->optionText[i]->width > maxTextWidth) {
+            maxTextWidth = landingMenu->optionText[i]->width;
+        }
+    }
 
     struct PrerenderedTextBatch* batch = prerenderedBatchStart();
     for (int i = 0; i < landingMenu->optionCount; ++i) {
@@ -161,7 +166,7 @@ void landingMenuRender(struct LandingMenu* landingMenu, struct RenderState* rend
 			gDPFillRectangle(renderState->dl++,
                 landingMenu->optionText[i]->x - paddingDepthX,
                 landingMenu->optionText[i]->y - paddingDepthY,
-                highlightWidth + paddingDepthX,
+                landingMenu->optionText[i]->x + maxTextWidth + paddingDepthX,
                 landingMenu->optionText[i]->y + getCurrentStrideValue(landingMenu) - paddingDepthY);
 		    gSPDisplayList(renderState->dl++, ui_material_revert_list[ORANGE_TRANSPARENT_OVERLAY_INDEX]);
 		}

--- a/src/menu/landing_menu.c
+++ b/src/menu/landing_menu.c
@@ -19,6 +19,11 @@
 #define PORTAL_LOGO_O_WIDTH  30
 #define PORTAL_LOGO_HEIGHT 47
 
+#define LANDING_MENU_TEXT_START_X 30
+#define LANDING_MENU_TEXT_START_Y 132
+#define STRIDE_OPTION_1 12
+#define STRIDE_OPTION_2 16
+
 Gfx portal_logo_gfx[] = {
     gsSPTextureRectangle(
         PORTAL_LOGO_X << 2,
@@ -55,12 +60,12 @@ Gfx portal_logo_gfx[] = {
 };
 
 void landingMenuInitText(struct LandingMenu* landingMenu) {
-    int y = 132;
+    int y = LANDING_MENU_TEXT_START_Y;
 
-    int stride = landingMenu->optionCount > 4 ? 12 : 16;
+    int stride = landingMenu->optionCount > 4 ? STRIDE_OPTION_1 : STRIDE_OPTION_2;
 
     for (int i = 0; i < landingMenu->optionCount; ++i) {
-        landingMenu->optionText[i] = menuBuildPrerenderedText(&gDejaVuSansFont, translationsGet(landingMenu->options[i].messageId), 30, y, SCREEN_WD);
+        landingMenu->optionText[i] = menuBuildPrerenderedText(&gDejaVuSansFont, translationsGet(landingMenu->options[i].messageId), LANDING_MENU_TEXT_START_X, y, SCREEN_WD);
         y += stride;
     }
 }
@@ -124,7 +129,7 @@ struct LandingMenuOption* landingMenuUpdate(struct LandingMenu* landingMenu) {
 
 void landingMenuRender(struct LandingMenu* landingMenu, struct RenderState* renderState, struct GraphicsTask* task) {
     gSPDisplayList(renderState->dl++, ui_material_list[DEFAULT_UI_INDEX]);
-
+	
     if (landingMenu->darkenBackground) {
         gSPDisplayList(renderState->dl++, ui_material_list[SOLID_TRANSPARENT_OVERLAY_INDEX]);
         gDPFillRectangle(renderState->dl++, 0, 0, SCREEN_WD, SCREEN_HT);
@@ -134,12 +139,34 @@ void landingMenuRender(struct LandingMenu* landingMenu, struct RenderState* rend
     gSPDisplayList(renderState->dl++, ui_material_list[PORTAL_LOGO_INDEX]);
     gSPDisplayList(renderState->dl++, portal_logo_gfx);
     gSPDisplayList(renderState->dl++, ui_material_revert_list[PORTAL_LOGO_INDEX]);
+	
+	int paddingDepthY = 2;
+	int paddingDepthX = 4;
+	int highlightWidth = 120;
+	int stride = landingMenu->optionCount > 4 ? STRIDE_OPTION_1 : STRIDE_OPTION_2;
+	int landingMenuTextY = LANDING_MENU_TEXT_START_Y;
+	if (landingMenu->optionCount > 4){
+		paddingDepthY = 0;
+		highlightWidth = 140;
+	}
 
     struct PrerenderedTextBatch* batch = prerenderedBatchStart();
     for (int i = 0; i < landingMenu->optionCount; ++i) {
-        prerenderedBatchAdd(batch, landingMenu->optionText[i], landingMenu->selectedItem == i ? &gSelectionGray: &gColorWhite);
+        prerenderedBatchAdd(batch, landingMenu->optionText[i], &gColorWhite);
+		
+		if (landingMenu->selectedItem == i ){
+			gSPDisplayList(renderState->dl++, ui_material_list[ORANGE_TRANSPARENT_OVERLAY_INDEX]);
+			gDPFillRectangle(renderState->dl++, 
+			LANDING_MENU_TEXT_START_X - paddingDepthX, 
+			landingMenuTextY - paddingDepthY,
+			highlightWidth + paddingDepthX, 
+			landingMenuTextY + stride - paddingDepthY);
+			
+		gSPDisplayList(renderState->dl++, ui_material_revert_list[SOLID_ENV_INDEX]);
+		}
+		landingMenuTextY += stride;
     }
+				
     renderState->dl = prerenderedBatchFinish(batch, gDejaVuSansImages, renderState->dl);
     gSPDisplayList(renderState->dl++, ui_material_revert_list[DEJAVU_SANS_0_INDEX]);
-
 }

--- a/src/menu/landing_menu.h
+++ b/src/menu/landing_menu.h
@@ -22,6 +22,6 @@ void landingMenuInit(struct LandingMenu* landingMenu, struct LandingMenuOption* 
 void landingMenuRebuildText(struct LandingMenu* landingMenu);
 struct LandingMenuOption* landingMenuUpdate(struct LandingMenu* landingMenu);
 void landingMenuRender(struct LandingMenu* landingMenu, struct RenderState* renderState, struct GraphicsTask* task);
-
+int getCurrentStrideValue(struct LandingMenu* landingMenu);
 
 #endif


### PR DESCRIPTION
Pull request to resolve issues with UI readability as stated in #495. 

**Implemented**
- Added orange rectangle around the selected UI item 
- Refactored code to support different menu options (stride 1 and stride 2)

**Tested on**
- Project 64 - 3.0.1.5664 - 2df3434
- M64py 0.2.5 
- RetroArch - ParaLLEl N64 core - GFX plugin AngryLion - Video driver Vulkan

**Screenshots**
![Portal64-orange-1](https://github.com/lambertjamesd/portal64/assets/51084209/1888d1dd-3f1b-43d9-aaf3-53c9d259d31b)

![Portal64-orange-2](https://github.com/lambertjamesd/portal64/assets/51084209/41ab36c5-3a6c-4409-8aae-e5a79b76f9f9)

